### PR TITLE
Setup tracing and tokio-console

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["--cfg", "tokio_unstable"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,9 @@
 [workspace]
 members = ["crates/server"]
 resolver = "2"
+
+[workspace.dependencies]
+console-subscriber = "0.5.0"
+tracing = "0.1.44"
+tracing-subscriber = "0.3.22"
+tokio = { version = "1", features = ["full"] }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -5,3 +5,7 @@ edition = "2024"
 license = "Apache-2.0"
 
 [dependencies]
+console-subscriber = { workspace = true, features = ["env-filter"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+tokio = { workspace = true }

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -1,0 +1,37 @@
+use tracing::level_filters::LevelFilter;
+
+/// Ocypode server configuration.
+pub struct ServerConfig {
+    pub logger: LoggerConfig,
+}
+
+impl ServerConfig {
+    // TODO: should load config from file.
+    pub fn new() -> Self {
+        Self { logger: LoggerConfig::default() }
+    }
+}
+
+pub struct LoggerConfig {
+    pub name: String,
+    pub enable_tokio_console: bool,
+    pub with_thread_name: bool,
+    pub default_level: LevelFilter,
+}
+
+impl Default for LoggerConfig {
+    fn default() -> Self {
+        Self::new("ocypode")
+    }
+}
+
+impl LoggerConfig {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            enable_tokio_console: true,
+            with_thread_name: false,
+            default_level: LevelFilter::INFO,
+        }
+    }
+}

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -29,7 +29,7 @@ impl LoggerConfig {
     pub fn new(name: impl Into<String>) -> Self {
         Self {
             name: name.into(),
-            enable_tokio_console: true,
+            enable_tokio_console: false,
             with_thread_name: false,
             default_level: LevelFilter::INFO,
         }

--- a/crates/server/src/logger.rs
+++ b/crates/server/src/logger.rs
@@ -1,0 +1,55 @@
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::{Layer, filter::Targets, layer::SubscriberExt, registry::Registry};
+
+use crate::config::LoggerConfig;
+
+pub fn init_ocypode_logger(config: &LoggerConfig) {
+    let mut layers = Vec::new();
+
+    let targets = Targets::new().with_default(config.default_level);
+
+    let fmt_layer = tracing_subscriber::fmt::layer()
+        .with_thread_names(config.with_thread_name)
+        .with_filter(targets)
+        .boxed();
+    layers.push(fmt_layer);
+
+    // Isolate the console subscriber server in a dedicated OS thread and runtime.
+    // This ensures the monitoring server remains accessible for debugging even if
+    // the main Tokio runtime experiences heavy load, starvation, or deadlocks.
+    if config.enable_tokio_console {
+        let (layer, server) =
+            console_subscriber::ConsoleLayer::builder().with_default_env().build();
+
+        let console_layer = layer
+            .with_filter(
+                Targets::new()
+                    .with_target("tokio", LevelFilter::TRACE)
+                    .with_target("runtime", LevelFilter::TRACE),
+            )
+            .boxed();
+
+        layers.push(console_layer);
+
+        std::thread::Builder::new()
+            .name(format!("{} tokio-console", config.name))
+            .spawn(move || {
+                tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("failed to build tokio-console runtime")
+                    .block_on(async move {
+                        println!("serving console subscriber");
+                        if let Err(e) = server.serve().await {
+                            eprintln!("console subscriber server error: {}", e);
+                        }
+                    });
+            })
+            .expect("failed to spawn console subscriber thread");
+    }
+
+    let subscriber = Registry::default().with(layers);
+
+    tracing::subscriber::set_global_default(subscriber)
+        .expect("failed to set global tracing subscriber");
+}

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,3 +1,14 @@
+use tracing::info;
+
+use crate::{config::ServerConfig, logger::init_ocypode_logger};
+
+mod config;
+mod logger;
+
 fn main() {
-    println!("Hello, world!");
+    let config = ServerConfig::new();
+    init_ocypode_logger(&config.logger);
+
+    info!("Starting ocypode-server");
+    info!("Server is ready");
 }


### PR DESCRIPTION
This pull request introduces a structured logging and monitoring setup for the `ocypode-server` crate, enabling enhanced observability and debugging capabilities. The key changes include the addition of configuration types for logging, integration of the `tracing` and `tokio-console` libraries, and initialization of the logger and monitoring server in the application entrypoint.

**Logging and Monitoring Integration:**

* Added `LoggerConfig` and `ServerConfig` types in `crates/server/src/config.rs` to centralize configuration for logging, including log level, thread name display, and enabling the Tokio console subscriber.
* Implemented the `init_ocypode_logger` function in `crates/server/src/logger.rs` to set up the tracing subscriber, configure log formatting, and launch the Tokio console subscriber in a dedicated thread and runtime for robust monitoring.

**Dependency and Build Configuration:**

* Added `console-subscriber`, `tracing`, `tracing-subscriber`, and `tokio` as workspace dependencies in `Cargo.toml` and enabled them in `crates/server/Cargo.toml` with relevant features. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R4-R9) [[2]](diffhunk://#diff-e69b576d0ecfb734851abf4882a8a231930a77092948b45464c06ae19e45e3cbR8-R11)
* Updated `.cargo/config.toml` to pass the `tokio_unstable` configuration flag, enabling advanced Tokio features required by the console subscriber.

**Application Entry Point Update:**

* Modified `crates/server/src/main.rs` to initialize the logger using the new configuration and log startup messages using the `tracing` crate.