### PR TITLE
Set up gRPC health check

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,7 @@ console-subscriber = "0.5.0"
 tracing = "0.1.44"
 tracing-subscriber = "0.3.22"
 tokio = { version = "1", features = ["full"] }
+tokio-stream = "0.1.18"
+tokio-util = "0.7.18"
+tonic = "0.14.5"
+tonic-health = "0.14.5"

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -9,3 +9,7 @@ console-subscriber = { workspace = true, features = ["env-filter"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tokio = { workspace = true }
+tonic = { workspace = true }
+tonic-health = { workspace = true }
+tokio-stream  = { workspace = true }
+tokio-util = { workspace = true }

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -1,14 +1,23 @@
+use std::net::SocketAddr;
+
 use tracing::level_filters::LevelFilter;
 
 /// Ocypode server configuration.
 pub struct ServerConfig {
     pub logger: LoggerConfig,
+    pub grpc: GrpcConfig,
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl ServerConfig {
     // TODO: should load config from file.
     pub fn new() -> Self {
-        Self { logger: LoggerConfig::default() }
+        Self { logger: LoggerConfig::default(), grpc: GrpcConfig::default() }
     }
 }
 
@@ -33,5 +42,21 @@ impl LoggerConfig {
             with_thread_name: false,
             default_level: LevelFilter::INFO,
         }
+    }
+}
+
+pub struct GrpcConfig {
+    pub listen_addr: String,
+}
+
+impl Default for GrpcConfig {
+    fn default() -> Self {
+        Self { listen_addr: "[::1]:50051".to_string() }
+    }
+}
+
+impl GrpcConfig {
+    pub fn socket_addr(&self) -> SocketAddr {
+        self.listen_addr.parse().unwrap()
     }
 }

--- a/crates/server/src/grpc.rs
+++ b/crates/server/src/grpc.rs
@@ -1,0 +1,40 @@
+use std::net::SocketAddr;
+
+use tokio_stream::wrappers::TcpListenerStream;
+use tokio_util::sync::CancellationToken;
+use tonic_health::ServingStatus;
+use tracing::{error, info};
+
+use crate::config::GrpcConfig;
+
+/// Bootstraps the Ocypode gRPC server.
+///
+/// Returns when the `shutdown` token is triggered.
+pub async fn grpc_serve(config: &GrpcConfig, shutdown: CancellationToken) -> SocketAddr {
+    let (health_reporter, health_service) = tonic_health::server::health_reporter();
+    health_reporter.set_service_status("ocypode-service", ServingStatus::Serving).await;
+
+    let listener = tokio::net::TcpListener::bind(config.socket_addr()).await.unwrap();
+    let listen_addr = listener.local_addr().unwrap();
+
+    let server = tonic::transport::Server::builder()
+        .add_service(health_service)
+        .serve_with_incoming(TcpListenerStream::new(listener));
+
+    tokio::spawn(async move {
+        tokio::select! {
+            response = server => {
+                if let Err(e) = response {
+                    error!("Ocypose gRPC server error: {}", e)
+                }
+            }
+            _ = shutdown.cancelled() => {
+                info!("Ocypose gRPC server received shutdown signal");
+            }
+        }
+    });
+
+    info!("Ocypode gRPC server listening to {}", listen_addr);
+
+    listen_addr
+}

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod config;
+pub mod grpc;

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,14 +1,26 @@
+use tokio_util::sync::CancellationToken;
 use tracing::info;
 
-use crate::{config::ServerConfig, logger::init_ocypode_logger};
+use crate::{config::ServerConfig, grpc::grpc_serve, logger::init_ocypode_logger};
 
 mod config;
+mod grpc;
 mod logger;
 
-fn main() {
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let config = ServerConfig::new();
     init_ocypode_logger(&config.logger);
 
     info!("Starting ocypode-server");
+
+    let cancel_token = CancellationToken::new();
+
+    // Setup gRPC server.
+    grpc_serve(&config.grpc, cancel_token).await;
+
     info!("Server is ready");
+
+    tokio::signal::ctrl_c().await?;
+    Ok(())
 }

--- a/crates/server/tests/grpc_tests.rs
+++ b/crates/server/tests/grpc_tests.rs
@@ -1,0 +1,26 @@
+use server::{config::GrpcConfig, grpc::grpc_serve};
+use tokio_util::sync::CancellationToken;
+use tonic_health::pb::{HealthCheckRequest, health_client::HealthClient};
+
+#[tokio::test]
+async fn test_grpc_health_check() {
+    let config = GrpcConfig { listen_addr: "127.0.0.1:0".parse().unwrap() };
+
+    let cancellation_token = CancellationToken::new();
+
+    let listen_addr = grpc_serve(&config, cancellation_token).await;
+
+    let channel = tonic::transport::Endpoint::from_shared(format!("http://{}", listen_addr))
+        .unwrap()
+        .connect()
+        .await
+        .expect("Failed to connect to server");
+
+    let mut client = HealthClient::new(channel);
+
+    let request = HealthCheckRequest { service: "ocypode-service".to_string() };
+
+    let response = client.check(request).await.expect("Health check request failed").into_inner();
+
+    assert_eq!(response.status as i32, 1);
+}


### PR DESCRIPTION
This pull request introduces initial support for gRPC in the Ocypode server. It adds gRPC-related dependencies, configuration, server bootstrapping logic, and a health check endpoint, along with a test to verify health status. The changes are grouped into dependency additions, configuration updates, server implementation, and testing.

**Dependency additions:**

* Added `tonic`, `tonic-health`, `tokio-stream`, and `tokio-util` as dependencies in `Cargo.toml` and `crates/server/Cargo.toml` to enable gRPC functionality and async utilities. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R10-R13) [[2]](diffhunk://#diff-e69b576d0ecfb734851abf4882a8a231930a77092948b45464c06ae19e45e3cbR12-R15)

**Configuration updates:**

* Introduced `GrpcConfig` struct with a default listen address and integrated it into `ServerConfig` for gRPC server configuration. [[1]](diffhunk://#diff-2dc24e74ade83e8457a6346d8e7aa74f01c4607c5ce6cb057507fa15ad7f46bfR1-R20) [[2]](diffhunk://#diff-2dc24e74ade83e8457a6346d8e7aa74f01c4607c5ce6cb057507fa15ad7f46bfR47-R62)

**Server implementation:**

* Implemented the `grpc_serve` function in `crates/server/src/grpc.rs` to bootstrap the gRPC server with health reporting and graceful shutdown support.
* Updated `main.rs` to start the gRPC server asynchronously and handle shutdown signals.
* Added `config` and `grpc` modules to `lib.rs` for modularization.

**Testing:**

* Added a test in `grpc_tests.rs` to verify the gRPC health check endpoint returns a serving status for the Ocypode service.