### PR TITLE
Setup prometheus api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,4 @@ tokio-stream = "0.1.18"
 tokio-util = "0.7.18"
 tonic = "0.14.5"
 tonic-health = "0.14.5"
-hyper = { version = "0.14", features = ["server", "tcp"] }
 prometheus = {version = "0.14.0", features = ["process"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = ["crates/server"]
 resolver = "2"
 
 [workspace.dependencies]
+axum = "0.8.8"
 console-subscriber = "0.5.0"
 tracing = "0.1.44"
 tracing-subscriber = "0.3.22"
@@ -11,3 +12,5 @@ tokio-stream = "0.1.18"
 tokio-util = "0.7.18"
 tonic = "0.14.5"
 tonic-health = "0.14.5"
+hyper = { version = "0.14", features = ["server", "tcp"] }
+prometheus = {version = "0.14.0", features = ["process"] }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -13,3 +13,6 @@ tonic = { workspace = true }
 tonic-health = { workspace = true }
 tokio-stream  = { workspace = true }
 tokio-util = { workspace = true }
+axum = { workspace = true }
+hyper = { workspace = true , features = ["server", "tcp"] }
+prometheus = { workspace = true , features = ["process"] }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -14,5 +14,4 @@ tonic-health = { workspace = true }
 tokio-stream  = { workspace = true }
 tokio-util = { workspace = true }
 axum = { workspace = true }
-hyper = { workspace = true , features = ["server", "tcp"] }
 prometheus = { workspace = true , features = ["process"] }

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -6,6 +6,7 @@ use tracing::level_filters::LevelFilter;
 pub struct ServerConfig {
     pub logger: LoggerConfig,
     pub grpc: GrpcConfig,
+    pub metrics: MetricsConfig,
 }
 
 impl Default for ServerConfig {
@@ -17,7 +18,11 @@ impl Default for ServerConfig {
 impl ServerConfig {
     // TODO: should load config from file.
     pub fn new() -> Self {
-        Self { logger: LoggerConfig::default(), grpc: GrpcConfig::default() }
+        Self {
+            logger: LoggerConfig::default(),
+            grpc: GrpcConfig::default(),
+            metrics: MetricsConfig::default(),
+        }
     }
 }
 
@@ -58,5 +63,26 @@ impl Default for GrpcConfig {
 impl GrpcConfig {
     pub fn socket_addr(&self) -> SocketAddr {
         self.listen_addr.parse().unwrap()
+    }
+}
+
+pub struct MetricsConfig {
+    pub metrics_level: MetricLevel,
+    pub listen_addr: String,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd)]
+pub enum MetricLevel {
+    #[default]
+    Disabled = 0,
+    Critical = 1,
+    Info = 2,
+    Debug = 3,
+}
+
+impl Default for MetricsConfig {
+    fn default() -> Self {
+        Self { metrics_level: MetricLevel::default(), listen_addr: "127.0.0.1:9090".to_string() }
     }
 }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,11 +1,17 @@
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
-use crate::{config::ServerConfig, grpc::grpc_serve, logger::init_ocypode_logger};
+use crate::{
+    config::{MetricLevel, ServerConfig},
+    grpc::grpc_serve,
+    logger::init_ocypode_logger,
+    metrics::MetricsManager,
+};
 
 mod config;
 mod grpc;
 mod logger;
+mod metrics;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -17,7 +23,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cancel_token = CancellationToken::new();
 
     // Setup gRPC server.
-    grpc_serve(&config.grpc, cancel_token).await;
+    grpc_serve(&config.grpc, cancel_token.clone()).await;
+
+    // Setup metrics service.
+    if config.metrics.metrics_level > MetricLevel::Disabled {
+        MetricsManager::boot_metrics_service(
+            config.metrics.listen_addr.clone(),
+            cancel_token.clone(),
+        );
+    }
 
     info!("Server is ready");
 

--- a/crates/server/src/metrics.rs
+++ b/crates/server/src/metrics.rs
@@ -1,0 +1,83 @@
+use std::sync::{LazyLock, OnceLock};
+
+use axum::Router;
+use axum::body::Body;
+use axum::response::Response;
+use axum::routing::get;
+use prometheus::{
+    Encoder, IntCounter, IntGauge, TextEncoder, register_int_counter, register_int_gauge,
+};
+use tokio::net::TcpListener;
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info, warn};
+
+pub struct MetricsManager;
+
+impl MetricsManager {
+    pub fn boot_metrics_service(listen_addr: String, shutdown: CancellationToken) {
+        static METRICS_SERVICE_LISTEN_ADDR: OnceLock<String> = OnceLock::new();
+        let requested_addr = listen_addr.clone();
+
+        let current_listen_addr = METRICS_SERVICE_LISTEN_ADDR.get_or_init(|| {
+            let pc = prometheus::process_collector::ProcessCollector::for_self();
+            let _ = prometheus::register(Box::new(pc));
+
+            let spawn_addr = listen_addr.clone();
+
+            info!("Prometheus listening to {}", spawn_addr);
+
+            tokio::spawn(async move {
+                let service = Router::new().route("/metrics", get(metrics)).into_make_service();
+                let listener = TcpListener::bind(&spawn_addr).await.unwrap();
+
+                let serve_future =
+                    axum::serve(listener, service).with_graceful_shutdown(async move {
+                        shutdown.cancelled().await;
+                        info!("Prometheus service shutting down");
+                    });
+
+                if let Err(err) = serve_future.await {
+                    error!(%err, "metrics service exited with error");
+                }
+            });
+
+            listen_addr
+        });
+
+        if requested_addr != *current_listen_addr {
+            warn!(
+                "unable to listen port {} for metrics service. Currently listening on {}",
+                requested_addr, current_listen_addr
+            );
+        }
+    }
+}
+
+async fn metrics() -> Response<Body> {
+    let mf = prometheus::gather();
+
+    let encoder = TextEncoder::new();
+    let mut buffer = Vec::new();
+    encoder.encode(&mf, &mut buffer).unwrap();
+
+    Response::builder()
+        .header(axum::http::header::CONTENT_TYPE, encoder.format_type())
+        .body(Body::from(buffer))
+        .unwrap()
+}
+
+#[allow(dead_code)]
+pub static OCYPODE_ACTIVE_CONNECTIONS: LazyLock<IntGauge> = LazyLock::new(|| {
+    register_int_gauge!("ocypode_active_connections", "Current number of active QUIC connections")
+        .unwrap()
+});
+
+#[allow(dead_code)]
+pub static OCYPODE_MESSAGES_TOTAL: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!("ocypode_messages_total", "Total number of messages processed").unwrap()
+});
+
+#[allow(dead_code)]
+pub static OCYPODE_ERRORS_TOTAL: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!("ocypode_errors_total", "Total number of errors occurred").unwrap()
+});


### PR DESCRIPTION
This pull request introduces a metrics service to the server, enabling Prometheus-compatible monitoring and exposing new metrics endpoints. The changes include new dependencies, configuration options, and a dedicated `metrics` module for managing and serving metrics. The server now conditionally starts the metrics service based on configuration.

**Metrics Service Integration**

* Added a new `metrics` module (`crates/server/src/metrics.rs`) implementing a Prometheus-compatible metrics endpoint using `axum`, with counters and gauges for active connections, messages, and errors. The service is managed via `MetricsManager::boot_metrics_service`.
* Updated the server startup logic in `main.rs` to conditionally start the metrics service based on the configured metrics level.

**Configuration Enhancements**

* Introduced `MetricsConfig` and `MetricLevel` types in `config.rs`, allowing configuration of metrics level and listen address. Updated `ServerConfig` to include metrics configuration and set sensible defaults. [[1]](diffhunk://#diff-2dc24e74ade83e8457a6346d8e7aa74f01c4607c5ce6cb057507fa15ad7f46bfR9) [[2]](diffhunk://#diff-2dc24e74ade83e8457a6346d8e7aa74f01c4607c5ce6cb057507fa15ad7f46bfL20-R25) [[3]](diffhunk://#diff-2dc24e74ade83e8457a6346d8e7aa74f01c4607c5ce6cb057507fa15ad7f46bfR68-R88)

**Dependency Updates**

* Added `axum`, `hyper`, and `prometheus` dependencies to the workspace and server crate to support the new metrics functionality. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R6) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R15-R16) [[3]](diffhunk://#diff-e69b576d0ecfb734851abf4882a8a231930a77092948b45464c06ae19e45e3cbR16-R18)

**Codebase Organization**

* Registered the new `metrics` module in `main.rs` and updated imports to include metrics-related types and functions.