### PR TITLE
Add QUIC server and configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ tokio-util = "0.7.18"
 tonic = "0.14.5"
 tonic-health = "0.14.5"
 prometheus = {version = "0.14.0", features = ["process"] }
+s2n-quic = "1.76.0"

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -15,3 +15,4 @@ tokio-stream  = { workspace = true }
 tokio-util = { workspace = true }
 axum = { workspace = true }
 prometheus = { workspace = true , features = ["process"] }
+s2n-quic = { workspace = true }

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -1,4 +1,8 @@
-use std::net::SocketAddr;
+use std::{
+    io::{Error, ErrorKind},
+    net::SocketAddr,
+    path::Path,
+};
 
 use tracing::level_filters::LevelFilter;
 
@@ -7,6 +11,7 @@ pub struct ServerConfig {
     pub logger: LoggerConfig,
     pub grpc: GrpcConfig,
     pub metrics: MetricsConfig,
+    pub quic: QuicConfig,
 }
 
 impl Default for ServerConfig {
@@ -22,6 +27,7 @@ impl ServerConfig {
             logger: LoggerConfig::default(),
             grpc: GrpcConfig::default(),
             metrics: MetricsConfig::default(),
+            quic: QuicConfig::default(),
         }
     }
 }
@@ -84,5 +90,71 @@ pub enum MetricLevel {
 impl Default for MetricsConfig {
     fn default() -> Self {
         Self { metrics_level: MetricLevel::default(), listen_addr: "127.0.0.1:9090".to_string() }
+    }
+}
+
+pub struct QuicConfig {
+    pub listen_addr: String,
+    pub enable_gso: bool,
+    pub enable_gro: bool,
+    pub endpoint_limits: Option<usize>,
+    // QUIC requires TLS to be enabled.
+    pub tls: TLSConfig,
+}
+
+impl Default for QuicConfig {
+    fn default() -> Self {
+        QuicConfig {
+            listen_addr: "127.0.0.1:4433".to_string(),
+            enable_gso: true,
+            enable_gro: true,
+            endpoint_limits: None,
+            tls: TLSConfig::default(),
+        }
+    }
+}
+
+impl QuicConfig {
+    pub fn socket_addr(&self) -> SocketAddr {
+        self.listen_addr.parse().unwrap()
+    }
+}
+
+pub struct TLSConfig {
+    cert_file_path: String,
+    key_file_path: String,
+}
+
+impl Default for TLSConfig {
+    fn default() -> Self {
+        // TODO: load from configuration file
+        TLSConfig {
+            cert_file_path: "crates/certs/server.crt".to_string(),
+            key_file_path: "crates/certs/key.pem".to_string(),
+        }
+    }
+}
+
+impl TLSConfig {
+    pub fn cert_file_path(&self) -> Result<&Path, Error> {
+        let path = Path::new(&self.cert_file_path);
+        if !path.try_exists()? {
+            return Err(Error::new(
+                ErrorKind::NotFound,
+                format!("Certificate file not found at: {}", self.cert_file_path),
+            ));
+        }
+        Ok(path)
+    }
+
+    pub fn key_file_path(&self) -> Result<&Path, Error> {
+        let path = Path::new(&self.key_file_path);
+        if !path.try_exists()? {
+            return Err(Error::new(
+                ErrorKind::NotFound,
+                format!("Key file not found at: {}", self.key_file_path),
+            ));
+        }
+        Ok(path)
     }
 }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,5 +1,5 @@
 use tokio_util::sync::CancellationToken;
-use tracing::info;
+use tracing::{error, info};
 
 use crate::{
     config::{MetricLevel, ServerConfig},
@@ -12,6 +12,7 @@ mod config;
 mod grpc;
 mod logger;
 mod metrics;
+mod quic;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -32,6 +33,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             cancel_token.clone(),
         );
     }
+
+    // Start Ocypode Server
+    if let Err(e) = quic::start(&config.quic, cancel_token.clone()).await {
+        error!("{}", e);
+        return Err(e);
+    };
 
     info!("Server is ready");
 

--- a/crates/server/src/quic.rs
+++ b/crates/server/src/quic.rs
@@ -1,0 +1,54 @@
+use std::{error::Error, net::SocketAddr};
+
+use s2n_quic::{Server, provider::endpoint_limits};
+use tokio_util::sync::CancellationToken;
+use tracing::info;
+
+use crate::config::QuicConfig;
+
+pub async fn start(config: &QuicConfig, shutdown: CancellationToken) -> Result<(), Box<dyn Error>> {
+    let addr: SocketAddr = config.socket_addr();
+
+    let io = s2n_quic::provider::io::Default::builder()
+        .with_receive_address(addr)?
+        .with_gso(config.enable_gso)?
+        .with_gro(config.enable_gro)?
+        .build()?;
+
+    let endpoint_limits_config = if let Some(limit) = config.endpoint_limits {
+        endpoint_limits::Default::builder().with_inflight_handshake_limit(limit)?.build()?
+    } else {
+        endpoint_limits::Default::default()
+    };
+
+    let mut server = Server::builder()
+        .with_tls((config.tls.cert_file_path()?, config.tls.key_file_path()?))?
+        .with_io(io)?
+        .with_endpoint_limits(endpoint_limits_config)?
+        .start()?;
+
+    info!("Ocypode server listening to {}", addr);
+
+    loop {
+        tokio::select! {
+            _ = shutdown.cancelled() => {
+                info!("Ocypode server stopped gracefully");
+                break;
+            }
+            connection = server.accept() => {
+                if let Some(mut connection) = connection {
+                    tokio::spawn(async move {
+                        while let Ok(Some(mut _stream)) = connection.accept_bidirectional_stream().await {
+                            // TODO: implement quic task
+                            todo!()
+                        }
+                    });
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This pull request introduces QUIC protocol support to the server, including new configuration options and a startup routine for a QUIC server. The changes are grouped into two main themes: QUIC integration and configuration enhancements.

QUIC integration:

* Added a new `quic.rs` module implementing the QUIC server startup logic using `s2n_quic`, including support for GSO/GRO, endpoint limits, and TLS certificate loading. The server listens for connections and is integrated with the shutdown token for graceful termination.
* Updated `main.rs` to import and start the QUIC server during initialization, handling errors and ensuring proper logging. [[1]](diffhunk://#diff-a42ffea04d64e7fc4d2631a2544a356f5ba4efcfee01218a97c44d77cde6b9e7R15) [[2]](diffhunk://#diff-a42ffea04d64e7fc4d2631a2544a356f5ba4efcfee01218a97c44d77cde6b9e7R37-R42)

Configuration enhancements:

* Introduced the `QuicConfig` struct and its default implementation in `config.rs`, with fields for listen address, GSO/GRO toggles, endpoint limits, and TLS configuration.
* Added `TLSConfig` struct to manage certificate and key file paths, including error handling for missing files.
* Extended `ServerConfig` to include the new `quic` field and updated its default implementation accordingly. [[1]](diffhunk://#diff-2dc24e74ade83e8457a6346d8e7aa74f01c4607c5ce6cb057507fa15ad7f46bfR14) [[2]](diffhunk://#diff-2dc24e74ade83e8457a6346d8e7aa74f01c4607c5ce6cb057507fa15ad7f46bfR30)
* Updated imports in `config.rs` to support new functionality for file and error handling.