### PR TITLE
Add tools crate to generate dev certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ Cargo.lock
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+# Certs
+certs/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/server"]
+members = ["crates/server", "tools"]
 resolver = "2"
 
 [workspace.dependencies]
@@ -14,3 +14,4 @@ tonic = "0.14.5"
 tonic-health = "0.14.5"
 prometheus = {version = "0.14.0", features = ["process"] }
 s2n-quic = "1.76.0"
+rcgen = "0.14.7"

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "tools"
+version = "0.1.0"
+edition = "2024"
+license = "Apache-2.0"
+
+[dependencies]
+rcgen = { workspace = true }

--- a/tools/src/bin/gen_dev_certs.rs
+++ b/tools/src/bin/gen_dev_certs.rs
@@ -1,0 +1,25 @@
+use std::{fs, path::PathBuf};
+
+fn main() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    // Since this is in crates/tools, we point back to crates/tests/certs
+    let certs_dir = manifest_dir.join("../crates/certs");
+
+    if !certs_dir.exists() {
+        fs::create_dir_all(&certs_dir).expect("failed to create certs directory");
+    }
+
+    let cert_path = certs_dir.join("server.crt");
+    let key_path = certs_dir.join("key.pem");
+
+    println!("Generating dev certificates...");
+    let cert =
+        rcgen::generate_simple_self_signed(vec!["localhost".into(), "127.0.0.1".into()]).unwrap();
+
+    fs::write(&cert_path, cert.cert.pem()).expect("failed to write server.crt");
+    fs::write(&key_path, cert.signing_key.serialize_pem()).expect("failed to write key.pem");
+
+    println!("Generated:");
+    println!("  cert: {}", cert_path.display());
+    println!("  key:  {}", key_path.display());
+}


### PR DESCRIPTION
Add a tools workspace member with a gen_dev_certs binary that uses rcgen to generate server.crt and key.pem into crates/certs. Add rcgen to workspace dependencies and ignore the certs/ directory in .gitignore