### PR TITLE
Add buf.yaml and pubsub proto files

### DIFF
--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -1,0 +1,5 @@
+version: v2
+
+lint:
+  use:
+    - STANDARD

--- a/proto/ocypode/pubsub/v1/pubsub.proto
+++ b/proto/ocypode/pubsub/v1/pubsub.proto
@@ -1,0 +1,4 @@
+syntax = "proto3";
+
+package ocypode.pubsub.v1;
+


### PR DESCRIPTION
Configure buf linting to use STANDARD and add a new proto file declaring package ocypode.pubsub.v1 and proto3 syntax