### PR TITLE
Implement FramedRead for QUIC streams and enhance QuicConfig

### DIFF
--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -7,6 +7,8 @@ use std::{
 use tracing::level_filters::LevelFilter;
 
 const QUIC_CONNECT_TIMEOUT_MS: u64 = 2000;
+// 32 KiB
+const QUIC_READ_BUFFER_SIZE: usize = 32 * 1024;
 
 /// Ocypode server configuration.
 pub struct ServerConfig {
@@ -101,6 +103,7 @@ pub struct QuicConfig {
     pub enable_gro: bool,
     pub endpoint_limits: Option<usize>,
     pub connect_timeout: u64,
+    pub read_buffer_size: usize,
     // QUIC requires TLS to be enabled.
     pub tls: TLSConfig,
 }
@@ -113,6 +116,7 @@ impl Default for QuicConfig {
             enable_gro: true,
             endpoint_limits: None,
             connect_timeout: QUIC_CONNECT_TIMEOUT_MS,
+            read_buffer_size: QUIC_READ_BUFFER_SIZE,
             tls: TLSConfig::default(),
         }
     }

--- a/crates/server/src/parser.rs
+++ b/crates/server/src/parser.rs
@@ -264,7 +264,11 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::io::Cursor;
+
     use prost::Message;
+    use tokio_stream::StreamExt;
+    use tokio_util::codec::FramedRead;
 
     use super::*;
 
@@ -423,5 +427,58 @@ mod tests {
             }
         }
         assert!(output_buffer.is_empty());
+    }
+
+    fn build_connect_frame(client_id: &str) -> Vec<u8> {
+        let conn = pb::Connect {
+            version: 1,
+            verbose: false,
+            client_id: client_id.to_string(),
+            credentials: None,
+        };
+        let mut codec = ClientCodec;
+        let mut buf = BytesMut::new();
+        codec.encode(conn, &mut buf).unwrap();
+        buf.to_vec()
+    }
+
+    #[tokio::test]
+    async fn framed_read_decodes_single_connect_frame() {
+        let data = build_connect_frame("cli-framed-1");
+        let cursor = Cursor::new(data);
+        let mut framed = FramedRead::with_capacity(cursor, ServerCodec, 32 * 1024);
+
+        let frame = framed.next().await.unwrap().unwrap();
+        assert!(matches!(frame, Frame::Connect(ref msg) if msg.client_id == "cli-framed-1"));
+        assert!(framed.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn framed_read_decodes_multiple_frames_in_sequence() {
+        let mut data = build_connect_frame("cli-framed-2a");
+        data.extend(build_connect_frame("cli-framed-2b"));
+        let cursor = Cursor::new(data);
+        let mut framed = FramedRead::with_capacity(cursor, ServerCodec, 32 * 1024);
+
+        let frame1 = framed.next().await.unwrap().unwrap();
+        assert!(matches!(frame1, Frame::Connect(ref msg) if msg.client_id == "cli-framed-2a"));
+
+        let frame2 = framed.next().await.unwrap().unwrap();
+        assert!(matches!(frame2, Frame::Connect(ref msg) if msg.client_id == "cli-framed-2b"));
+
+        assert!(framed.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn framed_read_recovers_from_bad_prefix_byte() {
+        let conn_data = build_connect_frame("cli-framed-3");
+        let mut data = vec![0xFF]; // invalid command byte
+        data.extend(conn_data);
+        let cursor = Cursor::new(data);
+        let mut framed = FramedRead::with_capacity(cursor, ServerCodec, 32 * 1024);
+
+        let frame = framed.next().await.unwrap().unwrap();
+        assert!(matches!(frame, Frame::Connect(ref msg) if msg.client_id == "cli-framed-3"));
+        assert!(framed.next().await.is_none());
     }
 }

--- a/crates/server/src/quic.rs
+++ b/crates/server/src/quic.rs
@@ -6,9 +6,10 @@ use s2n_quic::{
     provider::endpoint_limits,
     stream::{BidirectionalStream, ReceiveStream, SendStream},
 };
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::AsyncWriteExt;
+use tokio_stream::StreamExt;
 use tokio_util::{
-    codec::{Decoder, Encoder},
+    codec::{Encoder, FramedRead},
     sync::CancellationToken,
 };
 use tracing::info;
@@ -22,29 +23,22 @@ use crate::{
 /// Sends INFO to the client and awaits a CONNECT response within the given timeout.
 /// INFO is also re-sent when server configuration is updated.
 async fn perform_handshake(
-    receive_stream: &mut ReceiveStream,
+    framed_read: &mut FramedRead<ReceiveStream, ServerCodec>,
     send_stream: &mut SendStream,
-    incoming_bytes: &mut BytesMut,
-    codec: &mut ServerCodec,
     connect_timeout: Duration,
 ) -> Result<pb::Connect, ServerCodecError> {
     let mut output_buffer = BytesMut::new();
+    let mut codec = ServerCodec;
     codec.encode(ServerOutbound::default_info(), &mut output_buffer)?;
     send_stream.write_all(&output_buffer).await?;
 
     tokio::time::timeout(connect_timeout, async {
-        loop {
-            if let Some(frame) = codec.decode(incoming_bytes)? {
-                match frame {
-                    Frame::Connect(msg) => return Ok(msg),
-                }
-            }
-            let bytes_read = receive_stream.read_buf(incoming_bytes).await?;
-            if bytes_read == 0 {
-                return Err(ServerCodecError::Codec(CodecError::InvalidFormat(
-                    "connection closed before CONNECT".to_string(),
-                )));
-            }
+        match framed_read.next().await {
+            Some(Ok(Frame::Connect(msg))) => Ok(msg),
+            Some(Err(e)) => Err(e),
+            None => Err(ServerCodecError::Codec(CodecError::InvalidFormat(
+                "connection closed before CONNECT".to_string(),
+            ))),
         }
     })
     .await
@@ -65,29 +59,17 @@ fn handle_frame(frame: Frame) -> Result<(), ServerCodecError> {
 async fn handle_bidirectional_stream(
     stream: BidirectionalStream,
     connect_timeout: Duration,
+    read_buffer_size: usize,
 ) -> Result<(), ServerCodecError> {
-    let (mut receive_stream, mut send_stream) = stream.split();
-    let mut incoming_bytes = BytesMut::new();
-    let mut codec = ServerCodec;
+    let (receive_stream, mut send_stream) = stream.split();
+    let mut framed_read = FramedRead::with_capacity(receive_stream, ServerCodec, read_buffer_size);
 
-    let connect_msg = perform_handshake(
-        &mut receive_stream,
-        &mut send_stream,
-        &mut incoming_bytes,
-        &mut codec,
-        connect_timeout,
-    )
-    .await?;
+    let connect_msg =
+        perform_handshake(&mut framed_read, &mut send_stream, connect_timeout).await?;
     info!("Accepted CONNECT from client_id={}", connect_msg.client_id);
 
-    loop {
-        let bytes_read = receive_stream.read_buf(&mut incoming_bytes).await?;
-        if bytes_read == 0 {
-            break;
-        }
-        while let Some(frame) = codec.decode(&mut incoming_bytes)? {
-            handle_frame(frame)?;
-        }
+    while let Some(frame) = framed_read.next().await {
+        handle_frame(frame?)?;
     }
 
     Ok(())
@@ -121,6 +103,7 @@ pub async fn start(
     info!("Ocypode server listening to {}", local_addr);
 
     let connect_timeout = Duration::from_millis(config.connect_timeout);
+    let read_buffer_size = config.read_buffer_size;
     tokio::spawn(async move {
         loop {
             tokio::select! {
@@ -134,7 +117,7 @@ pub async fn start(
                             while let Ok(Some(stream)) = connection.accept_bidirectional_stream().await {
                                 let timeout = connect_timeout;
                                 tokio::spawn(async move {
-                                    if let Err(error) = handle_bidirectional_stream(stream, timeout).await {
+                                    if let Err(error) = handle_bidirectional_stream(stream, timeout, read_buffer_size).await {
                                         info!("QUIC stream error: {}", error);
                                     }
                                 });


### PR DESCRIPTION
This pull request introduces improvements to the QUIC stream handling in the server, focusing on more robust frame decoding and configurable read buffer sizing. The changes streamline how incoming frames are processed and add new tests to ensure reliability.

**Frame decoding improvements:**

* Replaced manual byte buffer parsing with `tokio_util::codec::FramedRead` for QUIC stream frame decoding, simplifying the code and making frame handling more reliable. (`crates/server/src/quic.rs`) [[1]](diffhunk://#diff-4b6b51f2933f80e5a3785b07dad9bb5dd67675a4493e413e27facd5ba5e0df32L25-R41) [[2]](diffhunk://#diff-4b6b51f2933f80e5a3785b07dad9bb5dd67675a4493e413e27facd5ba5e0df32R62-R72)
* Refactored the handshake logic to use `FramedRead`, improving the detection and handling of the initial `CONNECT` frame. (`crates/server/src/quic.rs`)

**Configuration enhancements:**

* Added a new `read_buffer_size` field to `QuicConfig` and set its default to 32 KiB, allowing the buffer size for frame decoding to be configured. (`crates/server/src/config.rs`) [[1]](diffhunk://#diff-2dc24e74ade83e8457a6346d8e7aa74f01c4607c5ce6cb057507fa15ad7f46bfR10-R11) [[2]](diffhunk://#diff-2dc24e74ade83e8457a6346d8e7aa74f01c4607c5ce6cb057507fa15ad7f46bfR106) [[3]](diffhunk://#diff-2dc24e74ade83e8457a6346d8e7aa74f01c4607c5ce6cb057507fa15ad7f46bfR119)
* Propagated the `read_buffer_size` setting throughout the QUIC server startup and stream handling logic. (`crates/server/src/quic.rs`) [[1]](diffhunk://#diff-4b6b51f2933f80e5a3785b07dad9bb5dd67675a4493e413e27facd5ba5e0df32R106) [[2]](diffhunk://#diff-4b6b51f2933f80e5a3785b07dad9bb5dd67675a4493e413e27facd5ba5e0df32L137-R120)

**Testing improvements:**

* Added async tests for `FramedRead` to verify decoding of single, multiple, and malformed frames, ensuring robustness in frame parsing. (`crates/server/src/parser.rs`)