### PR TITLE
Add configurable QUIC write buffer and use FramedWrite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,5 @@ prometheus = {version = "0.14.0", features = ["process"] }
 s2n-quic = "1.76.0"
 rcgen = "0.14.7"
 bytes = "1.11.1"
+futures-util = { version = "0.3", default-features = false, features = ["sink"] }
 thiserror = "2.0.18"

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -18,6 +18,7 @@ prometheus = { workspace = true , features = ["process"] }
 s2n-quic = { workspace = true }
 prost = { workspace = true }
 bytes = { workspace = true }
+futures-util = { workspace = true }
 thiserror = { workspace = true }
 
 [build-dependencies]

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -9,6 +9,8 @@ use tracing::level_filters::LevelFilter;
 const QUIC_CONNECT_TIMEOUT_MS: u64 = 2000;
 // 32 KiB
 const QUIC_READ_BUFFER_SIZE: usize = 32 * 1024;
+// 10 MiB
+const QUIC_WRITE_BUFFER_SIZE: usize = 10 * 1024 * 1024;
 
 /// Ocypode server configuration.
 pub struct ServerConfig {
@@ -104,6 +106,7 @@ pub struct QuicConfig {
     pub endpoint_limits: Option<usize>,
     pub connect_timeout: u64,
     pub read_buffer_size: usize,
+    pub write_buffer_size: usize,
     // QUIC requires TLS to be enabled.
     pub tls: TLSConfig,
 }
@@ -117,6 +120,7 @@ impl Default for QuicConfig {
             endpoint_limits: None,
             connect_timeout: QUIC_CONNECT_TIMEOUT_MS,
             read_buffer_size: QUIC_READ_BUFFER_SIZE,
+            write_buffer_size: QUIC_WRITE_BUFFER_SIZE,
             tls: TLSConfig::default(),
         }
     }

--- a/crates/server/src/quic.rs
+++ b/crates/server/src/quic.rs
@@ -1,15 +1,10 @@
 use std::{error::Error, net::SocketAddr, time::Duration};
 
-use bytes::BytesMut;
-use s2n_quic::{
-    Server,
-    provider::endpoint_limits,
-    stream::{BidirectionalStream, ReceiveStream, SendStream},
-};
-use tokio::io::AsyncWriteExt;
+use futures_util::SinkExt;
+use s2n_quic::{Server, provider::endpoint_limits, stream::BidirectionalStream};
 use tokio_stream::StreamExt;
 use tokio_util::{
-    codec::{Encoder, FramedRead},
+    codec::{FramedRead, FramedWrite},
     sync::CancellationToken,
 };
 use tracing::info;
@@ -22,15 +17,16 @@ use crate::{
 
 /// Sends INFO to the client and awaits a CONNECT response within the given timeout.
 /// INFO is also re-sent when server configuration is updated.
-async fn perform_handshake(
-    framed_read: &mut FramedRead<ReceiveStream, ServerCodec>,
-    send_stream: &mut SendStream,
+async fn perform_handshake<R, W>(
+    framed_read: &mut FramedRead<R, ServerCodec>,
+    framed_write: &mut FramedWrite<W, ServerCodec>,
     connect_timeout: Duration,
-) -> Result<pb::Connect, ServerCodecError> {
-    let mut output_buffer = BytesMut::new();
-    let mut codec = ServerCodec;
-    codec.encode(ServerOutbound::default_info(), &mut output_buffer)?;
-    send_stream.write_all(&output_buffer).await?;
+) -> Result<pb::Connect, ServerCodecError>
+where
+    R: tokio::io::AsyncRead + Unpin,
+    W: tokio::io::AsyncWrite + Unpin,
+{
+    framed_write.send(ServerOutbound::default_info()).await?;
 
     tokio::time::timeout(connect_timeout, async {
         match framed_read.next().await {
@@ -60,12 +56,14 @@ async fn handle_bidirectional_stream(
     stream: BidirectionalStream,
     connect_timeout: Duration,
     read_buffer_size: usize,
+    write_buffer_size: usize,
 ) -> Result<(), ServerCodecError> {
-    let (receive_stream, mut send_stream) = stream.split();
+    let (receive_stream, send_stream) = stream.split();
     let mut framed_read = FramedRead::with_capacity(receive_stream, ServerCodec, read_buffer_size);
+    let mut framed_write = FramedWrite::with_capacity(send_stream, ServerCodec, write_buffer_size);
 
     let connect_msg =
-        perform_handshake(&mut framed_read, &mut send_stream, connect_timeout).await?;
+        perform_handshake(&mut framed_read, &mut framed_write, connect_timeout).await?;
     info!("Accepted CONNECT from client_id={}", connect_msg.client_id);
 
     while let Some(frame) = framed_read.next().await {
@@ -104,6 +102,7 @@ pub async fn start(
 
     let connect_timeout = Duration::from_millis(config.connect_timeout);
     let read_buffer_size = config.read_buffer_size;
+    let write_buffer_size = config.write_buffer_size;
     tokio::spawn(async move {
         loop {
             tokio::select! {
@@ -117,7 +116,7 @@ pub async fn start(
                             while let Ok(Some(stream)) = connection.accept_bidirectional_stream().await {
                                 let timeout = connect_timeout;
                                 tokio::spawn(async move {
-                                    if let Err(error) = handle_bidirectional_stream(stream, timeout, read_buffer_size).await {
+                                    if let Err(error) = handle_bidirectional_stream(stream, timeout, read_buffer_size, write_buffer_size).await {
                                         info!("QUIC stream error: {}", error);
                                     }
                                 });
@@ -132,4 +131,46 @@ pub async fn start(
     });
 
     Ok(local_addr)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use futures_util::SinkExt;
+    use tokio_stream::StreamExt;
+    use tokio_util::codec::{FramedRead, FramedWrite};
+
+    use super::perform_handshake;
+    use crate::{
+        error::ServerCodecError,
+        parser::{ClientCodec, ClientOutbound, ServerCodec},
+    };
+
+    #[tokio::test]
+    async fn perform_handshake_sends_info_and_accepts_connect() {
+        let (client_io, server_io) = tokio::io::duplex(4096);
+        let (server_rx, server_tx) = tokio::io::split(server_io);
+        let (client_rx, client_tx) = tokio::io::split(client_io);
+
+        let server = async {
+            let mut framed_read = FramedRead::with_capacity(server_rx, ServerCodec, 4096);
+            let mut framed_write = FramedWrite::with_capacity(server_tx, ServerCodec, 4096);
+            perform_handshake(&mut framed_read, &mut framed_write, Duration::from_secs(1)).await
+        };
+
+        let client = async {
+            let mut framed_read = FramedRead::with_capacity(client_rx, ClientCodec, 4096);
+            let _info = framed_read.next().await.unwrap().unwrap();
+            let mut framed_write = FramedWrite::with_capacity(client_tx, ClientCodec, 4096);
+            framed_write
+                .send(ClientOutbound::connect(1, "test-client".to_string(), false))
+                .await
+                .unwrap();
+        };
+
+        let (result, _): (Result<_, ServerCodecError>, _) = tokio::join!(server, client);
+        let connect = result.unwrap();
+        assert_eq!(connect.client_id, "test-client");
+    }
 }


### PR DESCRIPTION
This pull request introduces improvements to QUIC stream handling in the server by adding configurable write buffer sizing and refactoring handshake logic to use framed codecs for both reading and writing. It also adds a unit test for the handshake process. These changes enhance performance and maintainability.

**QUIC Stream Handling Improvements:**

* Added a configurable `write_buffer_size` to `QuicConfig`, with a default value of 10 MiB, allowing better control over outgoing data buffering. (`crates/server/src/config.rs`, [[1]](diffhunk://#diff-2dc24e74ade83e8457a6346d8e7aa74f01c4607c5ce6cb057507fa15ad7f46bfR12-R13) [[2]](diffhunk://#diff-2dc24e74ade83e8457a6346d8e7aa74f01c4607c5ce6cb057507fa15ad7f46bfR109) [[3]](diffhunk://#diff-2dc24e74ade83e8457a6346d8e7aa74f01c4607c5ce6cb057507fa15ad7f46bfR123)
* Refactored `handle_bidirectional_stream` and `perform_handshake` to use `FramedWrite` for outgoing messages, replacing manual buffer management and improving code clarity and reliability. (`crates/server/src/quic.rs`, [[1]](diffhunk://#diff-4b6b51f2933f80e5a3785b07dad9bb5dd67675a4493e413e27facd5ba5e0df32L25-R29) [[2]](diffhunk://#diff-4b6b51f2933f80e5a3785b07dad9bb5dd67675a4493e413e27facd5ba5e0df32R59-R66)

**Dependency Updates:**

* Added `futures-util` as a dependency in both workspace and server crates to support new sink functionality. (`Cargo.toml`, [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R21); `crates/server/Cargo.toml`, [[2]](diffhunk://#diff-e69b576d0ecfb734851abf4882a8a231930a77092948b45464c06ae19e45e3cbR21)

**Testing Enhancements:**

* Introduced a unit test for `perform_handshake` to verify that INFO is sent and CONNECT is accepted, improving test coverage and reliability. (`crates/server/src/quic.rs`, [crates/server/src/quic.rsR135-R176](diffhunk://#diff-4b6b51f2933f80e5a3785b07dad9bb5dd67675a4493e413e27facd5ba5e0df32R135-R176))

**Integration/Plumbing:**

* Updated QUIC server startup logic to pass the new `write_buffer_size` parameter throughout stream handling. (`crates/server/src/quic.rs`, [[1]](diffhunk://#diff-4b6b51f2933f80e5a3785b07dad9bb5dd67675a4493e413e27facd5ba5e0df32R105) [[2]](diffhunk://#diff-4b6b51f2933f80e5a3785b07dad9bb5dd67675a4493e413e27facd5ba5e0df32L120-R119)