### PR TITLE
Send server-assigned client_id in INFO

### DIFF
--- a/crates/server/src/parser.rs
+++ b/crates/server/src/parser.rs
@@ -95,20 +95,22 @@ pub struct ServerOutbound;
 
 impl ServerOutbound {
     /// Creates an INFO message with specified parameters
-    pub fn info(version: u32, server_id: String, server_name: String) -> pb::Info {
+    pub fn info(version: u32, client_id: u64, server_id: String, server_name: String) -> pb::Info {
         pb::Info {
             version,
             auth_type: pb::info::AuthType::NoAuth as i32,
             server_id,
             server_name,
             max_payload: MAXIMUM_PAYLOAD_BYTES as u32,
+            client_id,
         }
     }
 
     /// Creates a default INFO message
     /// TODO: Load INFO message from configuration instead of using dummy values
+    #[allow(dead_code)]
     pub fn default_info() -> pb::Info {
-        Self::info(1, "ocypode-server".to_string(), "ocypode".to_string())
+        Self::info(1, 0, "ocypode-server".to_string(), "ocypode".to_string())
     }
 }
 
@@ -119,8 +121,8 @@ pub struct ClientOutbound;
 impl ClientOutbound {
     /// Creates a CONNECT message with specified parameters
     #[allow(dead_code)]
-    pub fn connect(version: u32, client_id: String, verbose: bool) -> pb::Connect {
-        pb::Connect { version, verbose, client_id, credentials: None }
+    pub fn connect(version: u32, verbose: bool) -> pb::Connect {
+        pb::Connect { version, verbose, credentials: None }
     }
 }
 
@@ -280,6 +282,7 @@ mod tests {
             server_id: "srv-1".to_string(),
             server_name: "ocypode".to_string(),
             max_payload: 1024,
+            client_id: 0,
         };
         let mut codec = ServerCodec;
         let mut output_buffer = BytesMut::new();
@@ -301,12 +304,7 @@ mod tests {
 
     #[test]
     fn decode_conn_frame_recovers_from_bad_prefix() {
-        let conn = pb::Connect {
-            version: 1,
-            verbose: true,
-            client_id: "cli-1".to_string(),
-            credentials: None,
-        };
+        let conn = pb::Connect { version: 1, verbose: true, credentials: None };
         let payload = conn.encode_to_vec();
 
         let invalid_command_byte = 0xFF; // intentionally invalid to force resync
@@ -318,11 +316,7 @@ mod tests {
 
         let mut codec = ServerCodec;
         let decoded = codec.decode(&mut incoming_bytes).unwrap().unwrap();
-        match decoded {
-            Frame::Connect(message) => {
-                assert_eq!(message.client_id, conn.client_id);
-            }
-        }
+        assert!(matches!(decoded, Frame::Connect(_)));
         assert!(incoming_bytes.is_empty());
     }
 
@@ -334,6 +328,7 @@ mod tests {
             server_id: "srv-2".to_string(),
             server_name: "ocypode".to_string(),
             max_payload: 2048,
+            client_id: 0,
         };
         let mut server_codec = ServerCodec;
         let mut client_codec = ClientCodec;
@@ -353,12 +348,7 @@ mod tests {
 
     #[test]
     fn client_encode_connect_frame_has_header_and_payload() {
-        let conn = pb::Connect {
-            version: 1,
-            verbose: true,
-            client_id: "cli-2".to_string(),
-            credentials: None,
-        };
+        let conn = pb::Connect { version: 1, verbose: true, credentials: None };
         let mut codec = ClientCodec;
         let mut output_buffer = BytesMut::new();
 
@@ -373,7 +363,7 @@ mod tests {
         assert_eq!(payload_length, payload_bytes.len());
 
         let decoded = pb::Connect::decode(payload_bytes).unwrap();
-        assert_eq!(decoded.client_id, conn.client_id);
+        assert_eq!(decoded.version, conn.version);
     }
 
     #[test]
@@ -384,6 +374,7 @@ mod tests {
             server_id: "srv-3".to_string(),
             server_name: "ocypode".to_string(),
             max_payload: 512,
+            client_id: 0,
         };
         let payload = info.encode_to_vec();
 
@@ -412,6 +403,7 @@ mod tests {
             server_id: "srv-4".to_string(),
             server_name: "ocypode".to_string(),
             max_payload: 4096,
+            client_id: 0,
         };
         let mut client_codec = ClientCodec;
         let mut server_codec = ServerCodec;
@@ -429,13 +421,8 @@ mod tests {
         assert!(output_buffer.is_empty());
     }
 
-    fn build_connect_frame(client_id: &str) -> Vec<u8> {
-        let conn = pb::Connect {
-            version: 1,
-            verbose: false,
-            client_id: client_id.to_string(),
-            credentials: None,
-        };
+    fn build_connect_frame() -> Vec<u8> {
+        let conn = pb::Connect { version: 1, verbose: false, credentials: None };
         let mut codec = ClientCodec;
         let mut buf = BytesMut::new();
         codec.encode(conn, &mut buf).unwrap();
@@ -444,41 +431,41 @@ mod tests {
 
     #[tokio::test]
     async fn framed_read_decodes_single_connect_frame() {
-        let data = build_connect_frame("cli-framed-1");
+        let data = build_connect_frame();
         let cursor = Cursor::new(data);
         let mut framed = FramedRead::with_capacity(cursor, ServerCodec, 32 * 1024);
 
         let frame = framed.next().await.unwrap().unwrap();
-        assert!(matches!(frame, Frame::Connect(ref msg) if msg.client_id == "cli-framed-1"));
+        assert!(matches!(frame, Frame::Connect(_)));
         assert!(framed.next().await.is_none());
     }
 
     #[tokio::test]
     async fn framed_read_decodes_multiple_frames_in_sequence() {
-        let mut data = build_connect_frame("cli-framed-2a");
-        data.extend(build_connect_frame("cli-framed-2b"));
+        let mut data = build_connect_frame();
+        data.extend(build_connect_frame());
         let cursor = Cursor::new(data);
         let mut framed = FramedRead::with_capacity(cursor, ServerCodec, 32 * 1024);
 
         let frame1 = framed.next().await.unwrap().unwrap();
-        assert!(matches!(frame1, Frame::Connect(ref msg) if msg.client_id == "cli-framed-2a"));
+        assert!(matches!(frame1, Frame::Connect(_)));
 
         let frame2 = framed.next().await.unwrap().unwrap();
-        assert!(matches!(frame2, Frame::Connect(ref msg) if msg.client_id == "cli-framed-2b"));
+        assert!(matches!(frame2, Frame::Connect(_)));
 
         assert!(framed.next().await.is_none());
     }
 
     #[tokio::test]
     async fn framed_read_recovers_from_bad_prefix_byte() {
-        let conn_data = build_connect_frame("cli-framed-3");
+        let conn_data = build_connect_frame();
         let mut data = vec![0xFF]; // invalid command byte
         data.extend(conn_data);
         let cursor = Cursor::new(data);
         let mut framed = FramedRead::with_capacity(cursor, ServerCodec, 32 * 1024);
 
         let frame = framed.next().await.unwrap().unwrap();
-        assert!(matches!(frame, Frame::Connect(ref msg) if msg.client_id == "cli-framed-3"));
+        assert!(matches!(frame, Frame::Connect(_)));
         assert!(framed.next().await.is_none());
     }
 }

--- a/crates/server/src/quic.rs
+++ b/crates/server/src/quic.rs
@@ -1,4 +1,9 @@
-use std::{error::Error, net::SocketAddr, time::Duration};
+use std::{
+    error::Error,
+    net::SocketAddr,
+    sync::atomic::{AtomicU64, Ordering},
+    time::Duration,
+};
 
 use futures_util::SinkExt;
 use s2n_quic::{Server, provider::endpoint_limits, stream::BidirectionalStream};
@@ -15,18 +20,23 @@ use crate::{
     parser::{Frame, ServerCodec, ServerOutbound, pb},
 };
 
+static CLIENT_ID_COUNTER: AtomicU64 = AtomicU64::new(1);
+
 /// Sends INFO to the client and awaits a CONNECT response within the given timeout.
 /// INFO is also re-sent when server configuration is updated.
 async fn perform_handshake<R, W>(
     framed_read: &mut FramedRead<R, ServerCodec>,
     framed_write: &mut FramedWrite<W, ServerCodec>,
     connect_timeout: Duration,
+    client_id: u64,
 ) -> Result<pb::Connect, ServerCodecError>
 where
     R: tokio::io::AsyncRead + Unpin,
     W: tokio::io::AsyncWrite + Unpin,
 {
-    framed_write.send(ServerOutbound::default_info()).await?;
+    let info =
+        ServerOutbound::info(1, client_id, "ocypode-server".to_string(), "ocypode".to_string());
+    framed_write.send(info).await?;
 
     tokio::time::timeout(connect_timeout, async {
         match framed_read.next().await {
@@ -45,8 +55,8 @@ where
 
 fn handle_frame(frame: Frame) -> Result<(), ServerCodecError> {
     match frame {
-        Frame::Connect(msg) => {
-            info!("Received unexpected CONNECT from client_id={}", msg.client_id);
+        Frame::Connect(_) => {
+            info!("Received unexpected CONNECT after handshake");
         }
     }
     Ok(())
@@ -62,9 +72,9 @@ async fn handle_bidirectional_stream(
     let mut framed_read = FramedRead::with_capacity(receive_stream, ServerCodec, read_buffer_size);
     let mut framed_write = FramedWrite::with_capacity(send_stream, ServerCodec, write_buffer_size);
 
-    let connect_msg =
-        perform_handshake(&mut framed_read, &mut framed_write, connect_timeout).await?;
-    info!("Accepted CONNECT from client_id={}", connect_msg.client_id);
+    let client_id = CLIENT_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
+    perform_handshake(&mut framed_read, &mut framed_write, connect_timeout, client_id).await?;
+    info!("Accepted CONNECT from client_id={}", client_id);
 
     while let Some(frame) = framed_read.next().await {
         handle_frame(frame?)?;
@@ -156,21 +166,19 @@ mod tests {
         let server = async {
             let mut framed_read = FramedRead::with_capacity(server_rx, ServerCodec, 4096);
             let mut framed_write = FramedWrite::with_capacity(server_tx, ServerCodec, 4096);
-            perform_handshake(&mut framed_read, &mut framed_write, Duration::from_secs(1)).await
+            perform_handshake(&mut framed_read, &mut framed_write, Duration::from_secs(1), 1).await
         };
 
         let client = async {
             let mut framed_read = FramedRead::with_capacity(client_rx, ClientCodec, 4096);
-            let _info = framed_read.next().await.unwrap().unwrap();
+            let info = framed_read.next().await.unwrap().unwrap();
+            let crate::parser::ClientFrame::Info(info_msg) = info;
+            assert_eq!(info_msg.client_id, 1);
             let mut framed_write = FramedWrite::with_capacity(client_tx, ClientCodec, 4096);
-            framed_write
-                .send(ClientOutbound::connect(1, "test-client".to_string(), false))
-                .await
-                .unwrap();
+            framed_write.send(ClientOutbound::connect(1, false)).await.unwrap();
         };
 
         let (result, _): (Result<_, ServerCodecError>, _) = tokio::join!(server, client);
-        let connect = result.unwrap();
-        assert_eq!(connect.client_id, "test-client");
+        result.unwrap();
     }
 }

--- a/crates/server/tests/protocol.rs
+++ b/crates/server/tests/protocol.rs
@@ -26,7 +26,7 @@ fn default_info_message() -> pb::Info {
 }
 
 fn sample_connect_message() -> pb::Connect {
-    ClientOutbound::connect(1, "client-1".to_string(), true)
+    ClientOutbound::connect(1, true)
 }
 
 async fn read_next_client_frame<ReceiveStream>(
@@ -124,6 +124,7 @@ async fn info_then_connect_over_quic() -> Result<(), TestError> {
     assert_eq!(info_message.server_id, expected_info.server_id);
     assert_eq!(info_message.server_name, expected_info.server_name);
     assert_eq!(info_message.max_payload, expected_info.max_payload);
+    assert!(info_message.client_id > 0, "server must assign a non-zero client_id");
 
     // Send CONNECT to server using ClientCodec (from parser.rs)
     let connect_message = sample_connect_message();

--- a/proto/ocypode/pubsub/v1/pubsub.proto
+++ b/proto/ocypode/pubsub/v1/pubsub.proto
@@ -34,6 +34,9 @@ message Info {
 
   // Maximum allowed payload size per message in bytes.
   uint32 max_payload = 5;
+
+  // Server-assigned unique identifier for this client connection.
+  uint64 client_id = 6;
 }
 
 // Connect is sent by the client after receiving the Info message.
@@ -46,10 +49,6 @@ message Connect {
   // Requests explicit acknowledgements (OK) from the server for every published message.
   // Enabling this increases network overhead but guarantees delivery tracking for strict use cases.
   bool verbose = 2;
-
-  // Client identifier used solely for server-side logging and troubleshooting.
-  // It does not affect routing or ephemeral session state.
-  string client_id = 3;
 
   // Authentication credentials.
   // The selected credential must satisfy the AuthType specified in the server's Info message.


### PR DESCRIPTION
Introduce CLIENT_ID_COUNTER to assign unique client IDs during handshake and include the assigned ID in the Server INFO message. Update perform_handshake signature, framing code, and tests accordingly.