### PR TITLE
Add TLS client verification and update protobufs

### DIFF
--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -135,6 +135,8 @@ impl QuicConfig {
 pub struct TLSConfig {
     pub cert_file_path: String,
     pub key_file_path: String,
+    /// When true, the server requires all clients to present a TLS certificate (mTLS).
+    pub client_verify: bool,
 }
 
 impl Default for TLSConfig {
@@ -143,6 +145,7 @@ impl Default for TLSConfig {
         TLSConfig {
             cert_file_path: "crates/certs/server.crt".to_string(),
             key_file_path: "crates/certs/key.pem".to_string(),
+            client_verify: false,
         }
     }
 }

--- a/crates/server/src/parser.rs
+++ b/crates/server/src/parser.rs
@@ -95,14 +95,22 @@ pub struct ServerOutbound;
 
 impl ServerOutbound {
     /// Creates an INFO message with specified parameters
-    pub fn info(version: u32, client_id: u64, server_id: String, server_name: String) -> pb::Info {
+    pub fn info(
+        version: u32,
+        client_id: u64,
+        server_id: String,
+        server_name: String,
+        requires_auth: bool,
+        tls_verify: bool,
+    ) -> pb::Info {
         pb::Info {
             version,
-            auth_type: pb::info::AuthType::NoAuth as i32,
             server_id,
             server_name,
             max_payload: MAXIMUM_PAYLOAD_BYTES as u32,
             client_id,
+            requires_auth,
+            tls_verify,
         }
     }
 
@@ -110,7 +118,7 @@ impl ServerOutbound {
     /// TODO: Load INFO message from configuration instead of using dummy values
     #[allow(dead_code)]
     pub fn default_info() -> pb::Info {
-        Self::info(1, 0, "ocypode-server".to_string(), "ocypode".to_string())
+        Self::info(1, 0, "ocypode-server".to_string(), "ocypode".to_string(), false, false)
     }
 }
 
@@ -122,7 +130,31 @@ impl ClientOutbound {
     /// Creates a CONNECT message with specified parameters
     #[allow(dead_code)]
     pub fn connect(version: u32, verbose: bool) -> pb::Connect {
-        pb::Connect { version, verbose, credentials: None }
+        pb::Connect {
+            version,
+            verbose,
+            auth_method: pb::AuthMethod::NoAuth as i32,
+            credentials: None,
+        }
+    }
+
+    /// Creates a CONNECT message with password credentials
+    #[allow(dead_code)]
+    pub fn connect_with_password(
+        version: u32,
+        verbose: bool,
+        username: String,
+        password: String,
+    ) -> pb::Connect {
+        pb::Connect {
+            version,
+            verbose,
+            auth_method: pb::AuthMethod::Password as i32,
+            credentials: Some(pb::connect::Credentials::PasswordAuth(pb::PasswordAuth {
+                username,
+                password,
+            })),
+        }
     }
 }
 
@@ -278,11 +310,12 @@ mod tests {
     fn encode_info_frame_has_header_and_payload() {
         let info = pb::Info {
             version: 1,
-            auth_type: pb::info::AuthType::NoAuth as i32,
             server_id: "srv-1".to_string(),
             server_name: "ocypode".to_string(),
             max_payload: 1024,
             client_id: 0,
+            requires_auth: false,
+            tls_verify: false,
         };
         let mut codec = ServerCodec;
         let mut output_buffer = BytesMut::new();
@@ -304,7 +337,12 @@ mod tests {
 
     #[test]
     fn decode_conn_frame_recovers_from_bad_prefix() {
-        let conn = pb::Connect { version: 1, verbose: true, credentials: None };
+        let conn = pb::Connect {
+            version: 1,
+            verbose: true,
+            auth_method: pb::AuthMethod::NoAuth as i32,
+            credentials: None,
+        };
         let payload = conn.encode_to_vec();
 
         let invalid_command_byte = 0xFF; // intentionally invalid to force resync
@@ -324,11 +362,12 @@ mod tests {
     fn encode_and_decode_info_frame() {
         let info = pb::Info {
             version: 1,
-            auth_type: pb::info::AuthType::NoAuth as i32,
             server_id: "srv-2".to_string(),
             server_name: "ocypode".to_string(),
             max_payload: 2048,
             client_id: 0,
+            requires_auth: false,
+            tls_verify: false,
         };
         let mut server_codec = ServerCodec;
         let mut client_codec = ClientCodec;
@@ -348,7 +387,12 @@ mod tests {
 
     #[test]
     fn client_encode_connect_frame_has_header_and_payload() {
-        let conn = pb::Connect { version: 1, verbose: true, credentials: None };
+        let conn = pb::Connect {
+            version: 1,
+            verbose: true,
+            auth_method: pb::AuthMethod::NoAuth as i32,
+            credentials: None,
+        };
         let mut codec = ClientCodec;
         let mut output_buffer = BytesMut::new();
 
@@ -370,11 +414,12 @@ mod tests {
     fn client_decode_info_frame_recovers_from_bad_prefix() {
         let info = pb::Info {
             version: 1,
-            auth_type: pb::info::AuthType::NoAuth as i32,
             server_id: "srv-3".to_string(),
             server_name: "ocypode".to_string(),
             max_payload: 512,
             client_id: 0,
+            requires_auth: false,
+            tls_verify: false,
         };
         let payload = info.encode_to_vec();
 
@@ -399,11 +444,12 @@ mod tests {
     fn client_encode_and_decode_info_frame() {
         let info = pb::Info {
             version: 2,
-            auth_type: pb::info::AuthType::NoAuth as i32,
             server_id: "srv-4".to_string(),
             server_name: "ocypode".to_string(),
             max_payload: 4096,
             client_id: 0,
+            requires_auth: false,
+            tls_verify: false,
         };
         let mut client_codec = ClientCodec;
         let mut server_codec = ServerCodec;
@@ -422,7 +468,12 @@ mod tests {
     }
 
     fn build_connect_frame() -> Vec<u8> {
-        let conn = pb::Connect { version: 1, verbose: false, credentials: None };
+        let conn = pb::Connect {
+            version: 1,
+            verbose: false,
+            auth_method: pb::AuthMethod::NoAuth as i32,
+            credentials: None,
+        };
         let mut codec = ClientCodec;
         let mut buf = BytesMut::new();
         codec.encode(conn, &mut buf).unwrap();

--- a/crates/server/src/quic.rs
+++ b/crates/server/src/quic.rs
@@ -34,8 +34,14 @@ where
     R: tokio::io::AsyncRead + Unpin,
     W: tokio::io::AsyncWrite + Unpin,
 {
-    let info =
-        ServerOutbound::info(1, client_id, "ocypode-server".to_string(), "ocypode".to_string());
+    let info = ServerOutbound::info(
+        1,
+        client_id,
+        "ocypode-server".to_string(),
+        "ocypode".to_string(),
+        false,
+        false,
+    );
     framed_write.send(info).await?;
 
     tokio::time::timeout(connect_timeout, async {
@@ -101,8 +107,17 @@ pub async fn start(
         endpoint_limits::Default::default()
     };
 
+    let tls = {
+        let tls_builder = s2n_quic::provider::tls::default::Server::builder()
+            .with_certificate(config.tls.cert_file_path()?, config.tls.key_file_path()?)?;
+        if config.tls.client_verify {
+            tls_builder.with_client_authentication()?.build()?
+        } else {
+            tls_builder.build()?
+        }
+    };
     let mut server = Server::builder()
-        .with_tls((config.tls.cert_file_path()?, config.tls.key_file_path()?))?
+        .with_tls(tls)?
         .with_io(io)?
         .with_endpoint_limits(endpoint_limits_config)?
         .start()?;

--- a/crates/server/tests/protocol.rs
+++ b/crates/server/tests/protocol.rs
@@ -120,7 +120,8 @@ async fn info_then_connect_over_quic() -> Result<(), TestError> {
     // Verify INFO message content
     let expected_info = default_info_message();
     assert_eq!(info_message.version, expected_info.version);
-    assert_eq!(info_message.auth_type, expected_info.auth_type);
+    assert_eq!(info_message.requires_auth, expected_info.requires_auth);
+    assert_eq!(info_message.tls_verify, expected_info.tls_verify);
     assert_eq!(info_message.server_id, expected_info.server_id);
     assert_eq!(info_message.server_name, expected_info.server_name);
     assert_eq!(info_message.max_payload, expected_info.max_payload);

--- a/proto/ocypode/pubsub/v1/pubsub.proto
+++ b/proto/ocypode/pubsub/v1/pubsub.proto
@@ -2,29 +2,24 @@ syntax = "proto3";
 
 package ocypode.pubsub.v1;
 
+// AuthMethod defines the application-level authentication methods.
+enum AuthMethod {
+  // No authentication required.
+  NO_AUTH = 0;
+  // Username and password authentication.
+  PASSWORD = 1;
+}
+
 // Info contains the server's configuration and capabilities.
 // This message must be exchanged during the initial handshake before a connection is established.
 //
 // For non-gRPC transports, the message must be prefixed with a 1-byte Command type
 // and a 4-byte payload length.
 message Info {
-  // AuthType defines the authentication methods supported or required by the server.
-  enum AuthType {
-    // No authentication required.
-    NO_AUTH = 0;
-    // Username and password authentication.
-    PASSWORD = 1;
-    // Token-based authentication.
-    TOKEN = 2;
-    // Mutual TLS (mTLS) authentication.
-    MTLS = 3;
-  }
-
   // Ocypode protocol version.
   uint32 version = 1;
 
-  // The authentication method required by the server.
-  AuthType auth_type = 2;
+  reserved 2; reserved "auth_type";
 
   // Unique identifier for the server instance.
   string server_id = 3;
@@ -37,12 +32,18 @@ message Info {
 
   // Server-assigned unique identifier for this client connection.
   uint64 client_id = 6;
+
+  // True when the server requires application-level authentication.
+  bool requires_auth = 7;
+
+  // True when the server requires client TLS certificates (mTLS).
+  bool tls_verify = 8;
 }
 
 // Connect is sent by the client after receiving the Info message.
 // It establishes the session parameters and provides necessary credentials.
 message Connect {
-  // Client's protocol version. 
+  // Client's protocol version.
   // Required to detect and gracefully handle protocol mismatches between client and server early.
   uint32 version = 1;
 
@@ -50,12 +51,14 @@ message Connect {
   // Enabling this increases network overhead but guarantees delivery tracking for strict use cases.
   bool verbose = 2;
 
-  // Authentication credentials.
-  // The selected credential must satisfy the AuthType specified in the server's Info message.
-  // If the server requires NO_AUTH or MTLS, this oneof should remain unset.
+  reserved 4, 5; reserved "password", "token";
+
+  // The authentication method the client wishes to use.
+  AuthMethod auth_method = 6;
+
+  // Authentication credentials matching the selected auth_method.
   oneof credentials {
-    PasswordAuth password = 4;
-    string token = 5;
+    PasswordAuth password_auth = 7;
   }
 }
 


### PR DESCRIPTION
Introduce client_verify flag on TLSConfig (default false) and wire it into the QUIC server TLS builder to enable client certificate authentication when true.

Update protobuf schema and generated code: rename AuthType ->
AuthMethod,
replace auth_type with requires_auth and tls_verify in Info, and adjust Connect auth fields. Update parser and tests to match the new fields.