### PR TITLE
Introduce Client and server abstractions with updated connection handling

### DIFF
--- a/crates/server/src/auth.rs
+++ b/crates/server/src/auth.rs
@@ -1,0 +1,25 @@
+// TODO: This module handles connection-time authentication (CONNECT message verification).
+//       Future work: PasswordAuthenticator, JWT-based auth, etc.
+//       Authorization (subject-level permissions) is handled separately in permission.rs.
+
+use crate::parser::pb;
+
+#[allow(dead_code)]
+pub enum AuthOutcome {
+    Accepted,
+    Rejected { reason: String },
+}
+
+/// Validates credentials presented in the CONNECT message.
+pub trait Authenticator: Send + Sync + 'static {
+    fn authenticate(&self, connect: &pb::Connect) -> AuthOutcome;
+}
+
+/// Accepts all connections without credential verification.
+pub struct NoAuthAuthenticator;
+
+impl Authenticator for NoAuthAuthenticator {
+    fn authenticate(&self, _connect: &pb::Connect) -> AuthOutcome {
+        AuthOutcome::Accepted
+    }
+}

--- a/crates/server/src/client.rs
+++ b/crates/server/src/client.rs
@@ -2,13 +2,17 @@
 //       FramedRead → Handshake → Frame dispatch → Permission check → Router → FramedWrite.
 //       Permission check (permission.rs) and routing (router.rs) are stubs pending implementation.
 
-use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
 
 use futures_util::SinkExt;
 use thiserror::Error;
-use tokio::io::{AsyncRead, AsyncWrite};
-use tokio::sync::mpsc;
+use tokio::{
+    io::{AsyncRead, AsyncWrite},
+    sync::mpsc,
+};
 use tokio_stream::StreamExt;
 use tokio_util::codec::{FramedRead, FramedWrite};
 
@@ -116,6 +120,7 @@ async fn perform_handshake<R: AsyncRead + Unpin>(
     info: pb::Info,
 ) -> Result<CompletedHandshake, ClientError> {
     use std::time::Duration;
+
     use tokio::time::timeout;
 
     outbound.send(OutboundMessage::Info(info)).await?;
@@ -144,15 +149,14 @@ fn dispatch_frame(
                 "client_id={} received unexpected CONNECT after handshake",
                 handshake.client_id
             );
-        }
-        // TODO: Frame::Publish(msg) => {
-        //     // permission_checker.check_publish(&msg.subject, handshake.client_id)?;
-        //     // router.publish(&msg.subject, msg.payload, handshake.client_id);
-        // }
-        // TODO: Frame::Subscribe(msg) => {
-        //     // permission_checker.check_subscribe(&msg.subject, handshake.client_id)?;
-        //     // router.subscribe(&msg.subject, handshake.client_id, outbound.clone());
-        // }
+        } /* TODO: Frame::Publish(msg) => {
+           *     // permission_checker.check_publish(&msg.subject, handshake.client_id)?;
+           *     // router.publish(&msg.subject, msg.payload, handshake.client_id);
+           * }
+           * TODO: Frame::Subscribe(msg) => {
+           *     // permission_checker.check_subscribe(&msg.subject, handshake.client_id)?;
+           *     // router.subscribe(&msg.subject, handshake.client_id, outbound.clone());
+           * } */
     }
     Ok(())
 }
@@ -229,11 +233,8 @@ mod tests {
         let (client_rx, client_tx) = tokio::io::split(client_io);
 
         let transport = DuplexTransport { reader: server_rx, writer: server_tx };
-        let client = Client::new(
-            transport,
-            Arc::new(NoAuthAuthenticator),
-            Arc::new(ServerConfig::new()),
-        );
+        let client =
+            Client::new(transport, Arc::new(NoAuthAuthenticator), Arc::new(ServerConfig::new()));
         let server = tokio::spawn(client.run());
 
         // Act as a network client: read INFO, send CONNECT.

--- a/crates/server/src/client.rs
+++ b/crates/server/src/client.rs
@@ -1,0 +1,254 @@
+// TODO: This module owns the per-connection pipeline:
+//       FramedRead → Handshake → Frame dispatch → Permission check → Router → FramedWrite.
+//       Permission check (permission.rs) and routing (router.rs) are stubs pending implementation.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use futures_util::SinkExt;
+use thiserror::Error;
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::sync::mpsc;
+use tokio_stream::StreamExt;
+use tokio_util::codec::{FramedRead, FramedWrite};
+
+static CLIENT_ID_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+use crate::{
+    auth::Authenticator,
+    config::ServerConfig,
+    error::ServerCodecError,
+    handshake::{CompletedHandshake, HandshakeError, PendingHandshake},
+    parser::{Frame, OutboundMessage, PROTOCOL_VERSION, ServerCodec, ServerOutbound, pb},
+    transport::Transport,
+};
+
+#[derive(Debug, Error)]
+pub enum ClientError {
+    #[error(transparent)]
+    Handshake(#[from] HandshakeError),
+    #[error(transparent)]
+    Codec(#[from] ServerCodecError),
+    #[error("outbound channel closed")]
+    OutboundChannelClosed,
+}
+
+impl From<mpsc::error::SendError<OutboundMessage>> for ClientError {
+    fn from(_: mpsc::error::SendError<OutboundMessage>) -> Self {
+        ClientError::OutboundChannelClosed
+    }
+}
+
+/// Server-side representation of a connected client.
+/// Created immediately after the QUIC stream is accepted, before the handshake.
+pub struct Client<R: AsyncRead + Unpin + Send> {
+    client_id: u64,
+    /// Read buffer (FramedRead holds a 32 KiB byte buffer internally).
+    framed_read: FramedRead<R, ServerCodec>,
+    /// Sender end of the outbound write-buffer channel.
+    /// The writer task drains this channel and batch-flushes to the network.
+    outbound_sender: mpsc::Sender<OutboundMessage>,
+    authenticator: Arc<dyn Authenticator>,
+    config: Arc<ServerConfig>,
+}
+
+impl<R: AsyncRead + Unpin + Send + 'static> Client<R> {
+    /// Constructs a client from any Transport.
+    /// Spawns an internal writer task that owns FramedWrite and the outbound channel receiver.
+    pub fn new<T: Transport<Reader = R>>(
+        transport: T,
+        authenticator: Arc<dyn Authenticator>,
+        config: Arc<ServerConfig>,
+    ) -> Self {
+        let client_id = CLIENT_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let (reader, writer) = transport.into_split();
+        let framed_read =
+            FramedRead::with_capacity(reader, ServerCodec, config.quic.read_buffer_size);
+        let framed_write =
+            FramedWrite::with_capacity(writer, ServerCodec, config.quic.write_buffer_size);
+
+        let (outbound_sender, outbound_receiver) =
+            mpsc::channel(config.quic.outbound_channel_capacity);
+        tokio::spawn(run_outbound_writer(framed_write, outbound_receiver));
+
+        Self { client_id, framed_read, outbound_sender, authenticator, config }
+    }
+
+    /// Runs the full client pipeline: handshake then frame dispatch.
+    pub async fn run(mut self) -> Result<(), ClientError> {
+        // Build INFO once from ServerConfig before entering the handshake.
+        let info = ServerOutbound::info(
+            PROTOCOL_VERSION,
+            self.client_id,
+            self.config.server_id.clone(),
+            self.config.server_name.clone(),
+            self.config.requires_auth,
+            self.config.tls_verify,
+        );
+
+        // Phase 1: Handshake
+        let completed = perform_handshake(
+            &mut self.framed_read,
+            &self.outbound_sender,
+            self.config.quic.connect_timeout,
+            PendingHandshake::new(self.client_id),
+            self.authenticator.as_ref(),
+            info,
+        )
+        .await?;
+        tracing::info!("client_id={} connection established", completed.client_id);
+
+        // Phase 2: Frame dispatch loop (hot path)
+        while let Some(frame) = self.framed_read.next().await {
+            dispatch_frame(frame?, &completed, &self.outbound_sender)?;
+        }
+
+        Ok(())
+    }
+}
+
+async fn perform_handshake<R: AsyncRead + Unpin>(
+    framed_read: &mut FramedRead<R, ServerCodec>,
+    outbound: &mpsc::Sender<OutboundMessage>,
+    connect_timeout_ms: u64,
+    pending: PendingHandshake,
+    authenticator: &dyn Authenticator,
+    info: pb::Info,
+) -> Result<CompletedHandshake, ClientError> {
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    outbound.send(OutboundMessage::Info(info)).await?;
+
+    timeout(Duration::from_millis(connect_timeout_ms), async {
+        match framed_read.next().await {
+            Some(Ok(Frame::Connect(connect))) => {
+                pending.on_connect(connect, authenticator).map_err(ClientError::Handshake)
+            }
+            Some(Err(e)) => Err(ClientError::Codec(e)),
+            None => Err(ClientError::Handshake(HandshakeError::ConnectionClosed)),
+        }
+    })
+    .await
+    .map_err(|_| ClientError::Handshake(HandshakeError::ConnectTimeout))?
+}
+
+fn dispatch_frame(
+    frame: Frame,
+    handshake: &CompletedHandshake,
+    _outbound: &mpsc::Sender<OutboundMessage>,
+) -> Result<(), ClientError> {
+    match frame {
+        Frame::Connect(_) => {
+            tracing::warn!(
+                "client_id={} received unexpected CONNECT after handshake",
+                handshake.client_id
+            );
+        }
+        // TODO: Frame::Publish(msg) => {
+        //     // permission_checker.check_publish(&msg.subject, handshake.client_id)?;
+        //     // router.publish(&msg.subject, msg.payload, handshake.client_id);
+        // }
+        // TODO: Frame::Subscribe(msg) => {
+        //     // permission_checker.check_subscribe(&msg.subject, handshake.client_id)?;
+        //     // router.subscribe(&msg.subject, handshake.client_id, outbound.clone());
+        // }
+    }
+    Ok(())
+}
+
+/// Drains the outbound channel and batch-flushes to FramedWrite.
+/// Minimizes syscall overhead by coalescing multiple messages into a single flush.
+async fn run_outbound_writer<W: AsyncWrite + Unpin>(
+    mut framed_write: FramedWrite<W, ServerCodec>,
+    mut receiver: mpsc::Receiver<OutboundMessage>,
+) {
+    while let Some(message) = receiver.recv().await {
+        let _ = dispatch_outbound(&mut framed_write, message).await;
+
+        // Non-blocking drain: feed all queued messages before flushing.
+        while let Ok(message) = receiver.try_recv() {
+            let _ = dispatch_outbound(&mut framed_write, message).await;
+        }
+
+        // One flush per batch → minimizes syscalls.
+        // The type annotation resolves ambiguity: ServerCodec encodes multiple item types.
+        let _ = SinkExt::<pb::Info>::flush(&mut framed_write).await;
+    }
+}
+
+async fn dispatch_outbound<W: AsyncWrite + Unpin>(
+    framed_write: &mut FramedWrite<W, ServerCodec>,
+    message: OutboundMessage,
+) -> Result<(), ServerCodecError> {
+    match message {
+        OutboundMessage::Info(info) => framed_write.feed(info).await?,
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use futures_util::SinkExt;
+    use tokio::io::{AsyncRead, AsyncWrite};
+    use tokio_stream::StreamExt;
+    use tokio_util::codec::{FramedRead, FramedWrite};
+
+    use super::Client;
+    use crate::{
+        auth::NoAuthAuthenticator,
+        config::ServerConfig,
+        parser::{ClientCodec, ClientFrame, ClientOutbound},
+        transport::Transport,
+    };
+
+    struct DuplexTransport<R, W> {
+        reader: R,
+        writer: W,
+    }
+
+    impl<R, W> Transport for DuplexTransport<R, W>
+    where
+        R: AsyncRead + Unpin + Send + 'static,
+        W: AsyncWrite + Unpin + Send + 'static,
+    {
+        type Reader = R;
+        type Writer = W;
+
+        fn into_split(self) -> (R, W) {
+            (self.reader, self.writer)
+        }
+    }
+
+    #[tokio::test]
+    async fn client_run_sends_info_and_accepts_connect() {
+        let (client_io, server_io) = tokio::io::duplex(4096);
+        let (server_rx, server_tx) = tokio::io::split(server_io);
+        let (client_rx, client_tx) = tokio::io::split(client_io);
+
+        let transport = DuplexTransport { reader: server_rx, writer: server_tx };
+        let client = Client::new(
+            transport,
+            Arc::new(NoAuthAuthenticator),
+            Arc::new(ServerConfig::new()),
+        );
+        let server = tokio::spawn(client.run());
+
+        // Act as a network client: read INFO, send CONNECT.
+        let mut framed_read = FramedRead::with_capacity(client_rx, ClientCodec, 4096);
+        let frame = framed_read.next().await.unwrap().unwrap();
+        let ClientFrame::Info(info_msg) = frame;
+        assert_eq!(info_msg.client_id, 1);
+
+        let mut framed_write = FramedWrite::with_capacity(client_tx, ClientCodec, 4096);
+        framed_write.send(ClientOutbound::connect(1, false)).await.unwrap();
+
+        // Drop the write end to signal EOF → server run() should finish cleanly.
+        drop(framed_write);
+        drop(framed_read);
+
+        server.await.unwrap().unwrap();
+    }
+}

--- a/crates/server/src/config.rs
+++ b/crates/server/src/config.rs
@@ -6,11 +6,17 @@ use std::{
 
 use tracing::level_filters::LevelFilter;
 
+// ── ServerConfig global defaults ─────────────────────────────────────────────
+const SERVER_ID: &str = "ocypode-server";
+const SERVER_NAME: &str = "ocypode";
+
+// ── QuicConfig defaults ───────────────────────────────────────────────────────
 const QUIC_CONNECT_TIMEOUT_MS: u64 = 2000;
 // 32 KiB
 const QUIC_READ_BUFFER_SIZE: usize = 32 * 1024;
 // 10 MiB
 const QUIC_WRITE_BUFFER_SIZE: usize = 10 * 1024 * 1024;
+const QUIC_OUTBOUND_CHANNEL_CAPACITY: usize = 1024;
 
 /// Ocypode server configuration.
 pub struct ServerConfig {
@@ -18,6 +24,15 @@ pub struct ServerConfig {
     pub grpc: GrpcConfig,
     pub metrics: MetricsConfig,
     pub quic: QuicConfig,
+    /// Unique identifier for this server instance, advertised in the INFO message.
+    pub server_id: String,
+    /// Human-readable server name, advertised in the INFO message.
+    pub server_name: String,
+    /// When true, the server advertises to clients that application-level authentication is required.
+    pub requires_auth: bool,
+    /// When true, the server requires clients to present a TLS certificate (mTLS).
+    /// This setting is also reflected in the INFO message sent to clients.
+    pub tls_verify: bool,
 }
 
 impl Default for ServerConfig {
@@ -34,6 +49,10 @@ impl ServerConfig {
             grpc: GrpcConfig::default(),
             metrics: MetricsConfig::default(),
             quic: QuicConfig::default(),
+            server_id: SERVER_ID.to_string(),
+            server_name: SERVER_NAME.to_string(),
+            requires_auth: false,
+            tls_verify: false,
         }
     }
 }
@@ -107,6 +126,9 @@ pub struct QuicConfig {
     pub connect_timeout: u64,
     pub read_buffer_size: usize,
     pub write_buffer_size: usize,
+    /// Capacity of the per-client outbound mpsc channel.
+    /// Higher values allow more messages to be queued before the writer task applies backpressure.
+    pub outbound_channel_capacity: usize,
     // QUIC requires TLS to be enabled.
     pub tls: TLSConfig,
 }
@@ -121,6 +143,7 @@ impl Default for QuicConfig {
             connect_timeout: QUIC_CONNECT_TIMEOUT_MS,
             read_buffer_size: QUIC_READ_BUFFER_SIZE,
             write_buffer_size: QUIC_WRITE_BUFFER_SIZE,
+            outbound_channel_capacity: QUIC_OUTBOUND_CHANNEL_CAPACITY,
             tls: TLSConfig::default(),
         }
     }
@@ -135,8 +158,6 @@ impl QuicConfig {
 pub struct TLSConfig {
     pub cert_file_path: String,
     pub key_file_path: String,
-    /// When true, the server requires all clients to present a TLS certificate (mTLS).
-    pub client_verify: bool,
 }
 
 impl Default for TLSConfig {
@@ -145,7 +166,6 @@ impl Default for TLSConfig {
         TLSConfig {
             cert_file_path: "crates/certs/server.crt".to_string(),
             key_file_path: "crates/certs/key.pem".to_string(),
-            client_verify: false,
         }
     }
 }

--- a/crates/server/src/handshake.rs
+++ b/crates/server/src/handshake.rs
@@ -48,10 +48,9 @@ impl PendingHandshake {
         authenticator: &dyn Authenticator,
     ) -> Result<CompletedHandshake, HandshakeError> {
         match authenticator.authenticate(&connect) {
-            AuthOutcome::Accepted => Ok(CompletedHandshake {
-                client_id: self.client_id,
-                connect_info: connect,
-            }),
+            AuthOutcome::Accepted => {
+                Ok(CompletedHandshake { client_id: self.client_id, connect_info: connect })
+            }
             AuthOutcome::Rejected { reason } => {
                 Err(HandshakeError::AuthenticationFailed { reason })
             }

--- a/crates/server/src/handshake.rs
+++ b/crates/server/src/handshake.rs
@@ -1,0 +1,79 @@
+// TODO: This module drives the per-connection handshake state machine.
+//       The type-state pattern enforces correct ordering at compile time:
+//       frames cannot be dispatched until authentication succeeds.
+
+use thiserror::Error;
+
+use crate::{
+    auth::{AuthOutcome, Authenticator},
+    parser::pb,
+};
+
+/// Initial state: INFO has been sent to the client, CONNECT has not yet arrived.
+pub struct PendingHandshake {
+    pub client_id: u64,
+}
+
+/// Terminal state: CONNECT received and authentication succeeded.
+pub struct CompletedHandshake {
+    pub client_id: u64,
+    /// The CONNECT message received from the client; available for future dispatch logic.
+    #[allow(dead_code)]
+    pub connect_info: pb::Connect,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Error)]
+pub enum HandshakeError {
+    #[error("CONNECT timeout")]
+    ConnectTimeout,
+    #[error("connection closed before CONNECT")]
+    ConnectionClosed,
+    /// Reserved for detecting frames arriving after the handshake is complete.
+    #[error("unexpected frame received after handshake")]
+    UnexpectedFrame,
+    #[error("authentication failed: {reason}")]
+    AuthenticationFailed { reason: String },
+}
+
+impl PendingHandshake {
+    pub fn new(client_id: u64) -> Self {
+        Self { client_id }
+    }
+
+    /// Validates the CONNECT message and transitions to the completed state.
+    pub fn on_connect(
+        self,
+        connect: pb::Connect,
+        authenticator: &dyn Authenticator,
+    ) -> Result<CompletedHandshake, HandshakeError> {
+        match authenticator.authenticate(&connect) {
+            AuthOutcome::Accepted => Ok(CompletedHandshake {
+                client_id: self.client_id,
+                connect_info: connect,
+            }),
+            AuthOutcome::Rejected { reason } => {
+                Err(HandshakeError::AuthenticationFailed { reason })
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::NoAuthAuthenticator;
+
+    #[test]
+    fn on_connect_transitions_to_completed_with_no_auth() {
+        let pending = PendingHandshake::new(42);
+        let connect = pb::Connect {
+            version: 1,
+            verbose: false,
+            auth_method: pb::AuthMethod::NoAuth as i32,
+            credentials: None,
+        };
+        let completed = pending.on_connect(connect, &NoAuthAuthenticator).unwrap();
+        assert_eq!(completed.client_id, 42);
+    }
+}

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -1,5 +1,11 @@
+pub mod auth;
+pub mod client;
 pub mod config;
 pub mod error;
 pub mod grpc;
+pub mod handshake;
 pub mod parser;
+pub mod permission;
 pub mod quic;
+pub mod router;
+pub mod transport;

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
@@ -8,17 +10,23 @@ use crate::{
     metrics::MetricsManager,
 };
 
+mod auth;
+mod client;
 mod config;
 mod error;
 mod grpc;
+mod handshake;
 mod logger;
 mod metrics;
 mod parser;
+mod permission;
 mod quic;
+mod router;
+mod transport;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let config = ServerConfig::new();
+    let config = Arc::new(ServerConfig::new());
     init_ocypode_logger(&config.logger);
 
     info!("Starting ocypode-server");
@@ -37,7 +45,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     }
 
     // Start Ocypode Server
-    let quic_addr = quic::start(&config.quic, cancel_token.clone()).await?;
+    let quic_addr = quic::start(Arc::clone(&config), cancel_token.clone()).await?;
     info!("QUIC server listening on {}", quic_addr);
 
     info!("Server is ready");

--- a/crates/server/src/parser.rs
+++ b/crates/server/src/parser.rs
@@ -12,6 +12,8 @@ const PAYLOAD_LENGTH_BYTES: usize = 4;
 const HEADER_LENGTH: usize = COMMAND_BYTE_LEN + PAYLOAD_LENGTH_BYTES;
 // Maximum payload is 1MiB.
 pub const MAXIMUM_PAYLOAD_BYTES: usize = 1024 * 1024;
+/// Current Ocypode protocol version.
+pub const PROTOCOL_VERSION: u32 = 1;
 
 /// Command classify Ocypode protocol.
 #[repr(u8)]
@@ -53,6 +55,13 @@ pub enum Frame {
 #[derive(Debug, Clone, PartialEq)]
 pub enum ClientFrame {
     Info(pb::Info),
+}
+
+/// Messages the server sends to a connected client.
+/// Used as the element type for the outbound write-buffer channel.
+pub enum OutboundMessage {
+    Info(pb::Info),
+    // TODO: Publish(pb::Publish), Pong, Error(pb::Error), etc.
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/server/src/permission.rs
+++ b/crates/server/src/permission.rs
@@ -1,0 +1,11 @@
+// TODO: This module will sit between frame dispatch and routing.
+//       Each inbound PUB/SUB command will be validated against the client's permission set
+//       before being forwarded to the router. Cedar-based policy evaluation is planned.
+
+/// Checks whether a client is authorized for publish or subscribe operations.
+// TODO: Implement with Cedar policy engine for fine-grained, attribute-based access control.
+#[allow(dead_code)]
+pub trait PermissionChecker: Send + Sync + 'static {
+    // TODO: fn check_publish(&self, subject: &str, client_id: u64) -> bool;
+    // TODO: fn check_subscribe(&self, subject: &str, client_id: u64) -> bool;
+}

--- a/crates/server/src/quic.rs
+++ b/crates/server/src/quic.rs
@@ -1,8 +1,4 @@
-use std::{
-    error::Error,
-    net::SocketAddr,
-    sync::Arc,
-};
+use std::{error::Error, net::SocketAddr, sync::Arc};
 
 use s2n_quic::{Server, provider::endpoint_limits, stream::BidirectionalStream};
 use tokio_util::sync::CancellationToken;

--- a/crates/server/src/quic.rs
+++ b/crates/server/src/quic.rs
@@ -1,116 +1,62 @@
 use std::{
     error::Error,
     net::SocketAddr,
-    sync::atomic::{AtomicU64, Ordering},
-    time::Duration,
+    sync::Arc,
 };
 
-use futures_util::SinkExt;
 use s2n_quic::{Server, provider::endpoint_limits, stream::BidirectionalStream};
-use tokio_stream::StreamExt;
-use tokio_util::{
-    codec::{FramedRead, FramedWrite},
-    sync::CancellationToken,
-};
+use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 use crate::{
-    config::QuicConfig,
-    error::{CodecError, ServerCodecError},
-    parser::{Frame, ServerCodec, ServerOutbound, pb},
+    auth::{Authenticator, NoAuthAuthenticator},
+    client::{Client, ClientError},
+    config::ServerConfig,
+    transport::Transport,
 };
 
-static CLIENT_ID_COUNTER: AtomicU64 = AtomicU64::new(1);
+impl Transport for BidirectionalStream {
+    type Reader = s2n_quic::stream::ReceiveStream;
+    type Writer = s2n_quic::stream::SendStream;
 
-/// Sends INFO to the client and awaits a CONNECT response within the given timeout.
-/// INFO is also re-sent when server configuration is updated.
-async fn perform_handshake<R, W>(
-    framed_read: &mut FramedRead<R, ServerCodec>,
-    framed_write: &mut FramedWrite<W, ServerCodec>,
-    connect_timeout: Duration,
-    client_id: u64,
-) -> Result<pb::Connect, ServerCodecError>
-where
-    R: tokio::io::AsyncRead + Unpin,
-    W: tokio::io::AsyncWrite + Unpin,
-{
-    let info = ServerOutbound::info(
-        1,
-        client_id,
-        "ocypode-server".to_string(),
-        "ocypode".to_string(),
-        false,
-        false,
-    );
-    framed_write.send(info).await?;
-
-    tokio::time::timeout(connect_timeout, async {
-        match framed_read.next().await {
-            Some(Ok(Frame::Connect(msg))) => Ok(msg),
-            Some(Err(e)) => Err(e),
-            None => Err(ServerCodecError::Codec(CodecError::InvalidFormat(
-                "connection closed before CONNECT".to_string(),
-            ))),
-        }
-    })
-    .await
-    .map_err(|_| {
-        ServerCodecError::Codec(CodecError::InvalidFormat("CONNECT message timeout".to_string()))
-    })?
-}
-
-fn handle_frame(frame: Frame) -> Result<(), ServerCodecError> {
-    match frame {
-        Frame::Connect(_) => {
-            info!("Received unexpected CONNECT after handshake");
-        }
+    fn into_split(self) -> (Self::Reader, Self::Writer) {
+        self.split()
     }
-    Ok(())
 }
 
 async fn handle_bidirectional_stream(
     stream: BidirectionalStream,
-    connect_timeout: Duration,
-    read_buffer_size: usize,
-    write_buffer_size: usize,
-) -> Result<(), ServerCodecError> {
-    let (receive_stream, send_stream) = stream.split();
-    let mut framed_read = FramedRead::with_capacity(receive_stream, ServerCodec, read_buffer_size);
-    let mut framed_write = FramedWrite::with_capacity(send_stream, ServerCodec, write_buffer_size);
-
-    let client_id = CLIENT_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
-    perform_handshake(&mut framed_read, &mut framed_write, connect_timeout, client_id).await?;
-    info!("Accepted CONNECT from client_id={}", client_id);
-
-    while let Some(frame) = framed_read.next().await {
-        handle_frame(frame?)?;
-    }
-
-    Ok(())
+    config: Arc<ServerConfig>,
+    authenticator: Arc<dyn Authenticator>,
+) -> Result<(), ClientError> {
+    let client = Client::new(stream, authenticator, config);
+    client.run().await
 }
 
 pub async fn start(
-    config: &QuicConfig,
+    config: Arc<ServerConfig>,
     shutdown: CancellationToken,
 ) -> Result<SocketAddr, Box<dyn Error + Send + Sync>> {
-    let addr: SocketAddr = config.socket_addr();
+    let addr: SocketAddr = config.quic.socket_addr();
 
     let io = s2n_quic::provider::io::Default::builder()
         .with_receive_address(addr)?
-        .with_gso(config.enable_gso)?
-        .with_gro(config.enable_gro)?
+        .with_gso(config.quic.enable_gso)?
+        .with_gro(config.quic.enable_gro)?
         .build()?;
 
-    let endpoint_limits_config = if let Some(limit) = config.endpoint_limits {
+    let endpoint_limits_config = if let Some(limit) = config.quic.endpoint_limits {
         endpoint_limits::Default::builder().with_inflight_handshake_limit(limit)?.build()?
     } else {
         endpoint_limits::Default::default()
     };
 
     let tls = {
-        let tls_builder = s2n_quic::provider::tls::default::Server::builder()
-            .with_certificate(config.tls.cert_file_path()?, config.tls.key_file_path()?)?;
-        if config.tls.client_verify {
+        let tls_builder = s2n_quic::provider::tls::default::Server::builder().with_certificate(
+            config.quic.tls.cert_file_path()?,
+            config.quic.tls.key_file_path()?,
+        )?;
+        if config.tls_verify {
             tls_builder.with_client_authentication()?.build()?
         } else {
             tls_builder.build()?
@@ -125,9 +71,8 @@ pub async fn start(
     let local_addr = server.local_addr()?;
     info!("Ocypode server listening to {}", local_addr);
 
-    let connect_timeout = Duration::from_millis(config.connect_timeout);
-    let read_buffer_size = config.read_buffer_size;
-    let write_buffer_size = config.write_buffer_size;
+    let authenticator: Arc<dyn Authenticator> = Arc::new(NoAuthAuthenticator);
+
     tokio::spawn(async move {
         loop {
             tokio::select! {
@@ -137,11 +82,14 @@ pub async fn start(
                 }
                 connection = server.accept() => {
                     if let Some(mut connection) = connection {
+                        let config = Arc::clone(&config);
+                        let authenticator = Arc::clone(&authenticator);
                         tokio::spawn(async move {
                             while let Ok(Some(stream)) = connection.accept_bidirectional_stream().await {
-                                let timeout = connect_timeout;
+                                let config = Arc::clone(&config);
+                                let auth = Arc::clone(&authenticator);
                                 tokio::spawn(async move {
-                                    if let Err(error) = handle_bidirectional_stream(stream, timeout, read_buffer_size, write_buffer_size).await {
+                                    if let Err(error) = handle_bidirectional_stream(stream, config, auth).await {
                                         info!("QUIC stream error: {}", error);
                                     }
                                 });
@@ -156,44 +104,4 @@ pub async fn start(
     });
 
     Ok(local_addr)
-}
-
-#[cfg(test)]
-mod tests {
-    use std::time::Duration;
-
-    use futures_util::SinkExt;
-    use tokio_stream::StreamExt;
-    use tokio_util::codec::{FramedRead, FramedWrite};
-
-    use super::perform_handshake;
-    use crate::{
-        error::ServerCodecError,
-        parser::{ClientCodec, ClientOutbound, ServerCodec},
-    };
-
-    #[tokio::test]
-    async fn perform_handshake_sends_info_and_accepts_connect() {
-        let (client_io, server_io) = tokio::io::duplex(4096);
-        let (server_rx, server_tx) = tokio::io::split(server_io);
-        let (client_rx, client_tx) = tokio::io::split(client_io);
-
-        let server = async {
-            let mut framed_read = FramedRead::with_capacity(server_rx, ServerCodec, 4096);
-            let mut framed_write = FramedWrite::with_capacity(server_tx, ServerCodec, 4096);
-            perform_handshake(&mut framed_read, &mut framed_write, Duration::from_secs(1), 1).await
-        };
-
-        let client = async {
-            let mut framed_read = FramedRead::with_capacity(client_rx, ClientCodec, 4096);
-            let info = framed_read.next().await.unwrap().unwrap();
-            let crate::parser::ClientFrame::Info(info_msg) = info;
-            assert_eq!(info_msg.client_id, 1);
-            let mut framed_write = FramedWrite::with_capacity(client_tx, ClientCodec, 4096);
-            framed_write.send(ClientOutbound::connect(1, false)).await.unwrap();
-        };
-
-        let (result, _): (Result<_, ServerCodecError>, _) = tokio::join!(server, client);
-        result.unwrap();
-    }
 }

--- a/crates/server/src/router.rs
+++ b/crates/server/src/router.rs
@@ -1,0 +1,12 @@
+// TODO: This module routes inbound PUB messages to matching subscribers.
+//       A trie-based subject matching algorithm (sublist pattern) is planned for O(depth) fan-out.
+//       Subscribers register their outbound channel sender so the router can deliver directly.
+
+/// Routes published messages to all matching subscribers.
+// TODO: Implement with a sublist trie for efficient wildcard subject matching.
+#[allow(dead_code)]
+pub trait Router: Send + Sync + 'static {
+    // TODO: fn publish(&self, subject: &str, payload: bytes::Bytes, sender_client_id: u64);
+    // TODO: fn subscribe(&self, subject: &str, client_id: u64, sender: tokio::sync::mpsc::Sender<crate::parser::OutboundMessage>);
+    // TODO: fn unsubscribe(&self, subject: &str, client_id: u64);
+}

--- a/crates/server/src/transport.rs
+++ b/crates/server/src/transport.rs
@@ -1,0 +1,10 @@
+use tokio::io::{AsyncRead, AsyncWrite};
+
+/// Abstracts a bidirectional byte stream transport.
+/// Implementations exist for QUIC (via s2n-quic) and can be added for TCP or WebSocket.
+pub trait Transport: Send + 'static {
+    type Reader: AsyncRead + Unpin + Send + 'static;
+    type Writer: AsyncWrite + Unpin + Send + 'static;
+
+    fn into_split(self) -> (Self::Reader, Self::Writer);
+}

--- a/crates/server/tests/protocol.rs
+++ b/crates/server/tests/protocol.rs
@@ -3,7 +3,7 @@ use std::{net::UdpSocket, path::Path, sync::Arc, time::Duration};
 use bytes::BytesMut;
 use s2n_quic::{Client, client::Connect};
 use server::{
-    config::QuicConfig,
+    config::ServerConfig,
     error::ClientCodecError,
     parser::{ClientCodec, ClientFrame, ClientOutbound, CommandCodec, ServerOutbound, pb},
 };
@@ -66,23 +66,21 @@ where
 
 async fn setup_server_and_client(
     connect_timeout: u64,
-) -> Result<(Arc<QuicConfig>, CancellationToken, s2n_quic::Client, std::net::SocketAddr), TestError>
+) -> Result<(Arc<ServerConfig>, CancellationToken, s2n_quic::Client, std::net::SocketAddr), TestError>
 {
-    let mut quic_config = QuicConfig {
-        enable_gso: false,
-        enable_gro: false,
-        listen_addr: "127.0.0.1:0".to_string(),
-        connect_timeout,
-        ..Default::default()
-    };
-    quic_config.tls.cert_file_path = "../certs/server.crt".to_string();
-    quic_config.tls.key_file_path = "../certs/key.pem".to_string();
+    let mut server_config = ServerConfig::new();
+    server_config.quic.enable_gso = false;
+    server_config.quic.enable_gro = false;
+    server_config.quic.listen_addr = "127.0.0.1:0".to_string();
+    server_config.quic.connect_timeout = connect_timeout;
+    server_config.quic.tls.cert_file_path = "../certs/server.crt".to_string();
+    server_config.quic.tls.key_file_path = "../certs/key.pem".to_string();
 
     let cancellation_token = CancellationToken::new();
-    let server_config = Arc::new(quic_config);
+    let server_config = Arc::new(server_config);
     let server_shutdown = cancellation_token.clone();
 
-    let server_address = server::quic::start(&server_config, server_shutdown).await?;
+    let server_address = server::quic::start(Arc::clone(&server_config), server_shutdown).await?;
 
     let client = Client::builder()
         .with_tls(Path::new("../certs/server.crt"))?


### PR DESCRIPTION
This pull request introduces a foundational server-side connection pipeline for Ocypode, including authentication, handshake, client management, and configuration improvements. The changes establish modular components for handling client connections, authentication, and handshake state, as well as extend configuration options for future scalability and security. Several modules are stubbed for future implementation, such as permission checking and routing.

**Connection Management and Pipeline**

* Added the `client.rs` module, which implements the per-connection pipeline: handshake, authentication, frame dispatch, outbound message batching, and client management. It includes a test for the handshake and INFO message flow. (`crates/server/src/client.rs`)
* Introduced the `handshake.rs` module, implementing a type-state handshake state machine to enforce authentication before frame dispatch. (`crates/server/src/handshake.rs`)
* Defined the `auth.rs` module, with an `Authenticator` trait and a default `NoAuthAuthenticator`. (`crates/server/src/auth.rs`)

**Configuration Enhancements**

* Expanded `ServerConfig` and `QuicConfig` with new fields: `server_id`, `server_name`, `requires_auth`, `tls_verify`, and `outbound_channel_capacity`, including sensible defaults. (`crates/server/src/config.rs`) [[1]](diffhunk://#diff-2dc24e74ade83e8457a6346d8e7aa74f01c4607c5ce6cb057507fa15ad7f46bfR9-R35) [[2]](diffhunk://#diff-2dc24e74ade83e8457a6346d8e7aa74f01c4607c5ce6cb057507fa15ad7f46bfR52-R55) [[3]](diffhunk://#diff-2dc24e74ade83e8457a6346d8e7aa74f01c4607c5ce6cb057507fa15ad7f46bfR129-R131) [[4]](diffhunk://#diff-2dc24e74ade83e8457a6346d8e7aa74f01c4607c5ce6cb057507fa15ad7f46bfR146)
* Removed the unused `client_verify` field from `TLSConfig`. (`crates/server/src/config.rs`) [[1]](diffhunk://#diff-2dc24e74ade83e8457a6346d8e7aa74f01c4607c5ce6cb057507fa15ad7f46bfL138-L139) [[2]](diffhunk://#diff-2dc24e74ade83e8457a6346d8e7aa74f01c4607c5ce6cb057507fa15ad7f46bfL148)

**Protocol and Message Handling**

* Added the `PROTOCOL_VERSION` constant and defined the `OutboundMessage` enum for server-to-client communication. (`crates/server/src/parser.rs`) [[1]](diffhunk://#diff-1cbe83b301f9b717d3a3694aa8edeeca70486381b8e96e7d6c995eaf86f3372cR15-R16) [[2]](diffhunk://#diff-1cbe83b301f9b717d3a3694aa8edeeca70486381b8e96e7d6c995eaf86f3372cR60-R66)

**Module Organization**

* Registered new modules in `lib.rs` and `main.rs`, and updated initialization to use `Arc` for shared configuration. (`crates/server/src/lib.rs`, `crates/server/src/main.rs`) [[1]](diffhunk://#diff-c1bf83c35ece0400d4cbaee4e7c0838621a5cc6f7c9c1f6f35e019399a50fdebR1-R11) [[2]](diffhunk://#diff-a42ffea04d64e7fc4d2631a2544a356f5ba4efcfee01218a97c44d77cde6b9e7R1-R2) [[3]](diffhunk://#diff-a42ffea04d64e7fc4d2631a2544a356f5ba4efcfee01218a97c44d77cde6b9e7R13-R29) [[4]](diffhunk://#diff-a42ffea04d64e7fc4d2631a2544a356f5ba4efcfee01218a97c44d77cde6b9e7L40-R48)

**Permission and Routing Stubs**

* Added stub modules for permission checking and routing, with planned Cedar policy engine integration. (`crates/server/src/permission.rs`)

These changes lay the groundwork for robust client connection handling, authentication, and future extensibility in the Ocypode server.