### PR TITLE
Add justfile with Rust format and lint tasks

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,14 @@
+_default:
+    @just --list
+
+# Format Rust Code
+fmt:
+    cargo +nightly fmt
+
+# Lint Rust Code
+lint:
+    cargo clippy
+
+# Fix lint Rust Code
+lint-fix:
+    cargo clippy --fix --allow-dirty


### PR DESCRIPTION
Default task lists available tasks. 'fmt' runs cargo +nightly fmt. 'lint' runs cargo clippy. 'lint-fix' runs cargo clippy --fix --allow-dirty.