### PR TITLE
Add PubSub v1 messages to proto

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/crates/server/src/client.rs
+++ b/crates/server/src/client.rs
@@ -130,6 +130,8 @@ async fn perform_handshake<R: AsyncRead + Unpin>(
             Some(Ok(Frame::Connect(connect))) => {
                 pending.on_connect(connect, authenticator).map_err(ClientError::Handshake)
             }
+            // Publish/Subscribe/UnSubscribe before handshake completes is invalid.
+            Some(Ok(_)) => Err(ClientError::Handshake(HandshakeError::ConnectionClosed)),
             Some(Err(e)) => Err(ClientError::Codec(e)),
             None => Err(ClientError::Handshake(HandshakeError::ConnectionClosed)),
         }
@@ -149,14 +151,9 @@ fn dispatch_frame(
                 "client_id={} received unexpected CONNECT after handshake",
                 handshake.client_id
             );
-        } /* TODO: Frame::Publish(msg) => {
-           *     // permission_checker.check_publish(&msg.subject, handshake.client_id)?;
-           *     // router.publish(&msg.subject, msg.payload, handshake.client_id);
-           * }
-           * TODO: Frame::Subscribe(msg) => {
-           *     // permission_checker.check_subscribe(&msg.subject, handshake.client_id)?;
-           *     // router.subscribe(&msg.subject, handshake.client_id, outbound.clone());
-           * } */
+        }
+        // TODO: permission check → router dispatch
+        Frame::Publish(_) | Frame::Subscribe(_) | Frame::UnSubscribe(_) => {}
     }
     Ok(())
 }
@@ -187,6 +184,8 @@ async fn dispatch_outbound<W: AsyncWrite + Unpin>(
 ) -> Result<(), ServerCodecError> {
     match message {
         OutboundMessage::Info(info) => framed_write.feed(info).await?,
+        // TODO: Message delivery to subscribers
+        OutboundMessage::Message(_) => {}
     }
     Ok(())
 }
@@ -240,7 +239,7 @@ mod tests {
         // Act as a network client: read INFO, send CONNECT.
         let mut framed_read = FramedRead::with_capacity(client_rx, ClientCodec, 4096);
         let frame = framed_read.next().await.unwrap().unwrap();
-        let ClientFrame::Info(info_msg) = frame;
+        let ClientFrame::Info(info_msg) = frame else { panic!("expected Info frame") };
         assert_eq!(info_msg.client_id, 1);
 
         let mut framed_write = FramedWrite::with_capacity(client_tx, ClientCodec, 4096);

--- a/crates/server/src/error.rs
+++ b/crates/server/src/error.rs
@@ -10,57 +10,23 @@ pub enum CodecError {
     #[error("Invalid command")]
     #[allow(dead_code)]
     InvalidCommand,
-    #[error("Invalid format: {0}")]
-    InvalidFormat(String),
+    #[error("Encode error: {0}")]
+    Encode(#[from] prost::EncodeError),
+    #[error("Decode error: {0}")]
+    Decode(#[from] prost::DecodeError),
     #[error("Invalid size bytes: {0}")]
     InvalidSizeBytes(usize),
     #[error("Invalid version: {0}")]
     #[allow(dead_code)]
     InvalidVersion(String),
-    #[error("IO error: {0}")]
-    IoError(String),
-}
-
-impl From<io::Error> for CodecError {
-    fn from(err: io::Error) -> Self {
-        CodecError::IoError(err.to_string())
-    }
-}
-
-impl From<prost::EncodeError> for CodecError {
-    fn from(err: prost::EncodeError) -> Self {
-        CodecError::InvalidFormat(err.to_string())
-    }
-}
-
-impl From<prost::DecodeError> for CodecError {
-    fn from(err: prost::DecodeError) -> Self {
-        CodecError::InvalidFormat(err.to_string())
-    }
 }
 
 #[derive(Debug, Error)]
 pub enum ServerCodecError {
     #[error(transparent)]
     Codec(#[from] CodecError),
-}
-
-impl From<io::Error> for ServerCodecError {
-    fn from(err: io::Error) -> Self {
-        ServerCodecError::Codec(CodecError::from(err))
-    }
-}
-
-impl From<prost::EncodeError> for ServerCodecError {
-    fn from(err: prost::EncodeError) -> Self {
-        ServerCodecError::Codec(CodecError::from(err))
-    }
-}
-
-impl From<prost::DecodeError> for ServerCodecError {
-    fn from(err: prost::DecodeError) -> Self {
-        ServerCodecError::Codec(CodecError::from(err))
-    }
+    #[error(transparent)]
+    Io(#[from] io::Error),
 }
 
 #[allow(dead_code)]
@@ -68,22 +34,6 @@ impl From<prost::DecodeError> for ServerCodecError {
 pub enum ClientCodecError {
     #[error(transparent)]
     Codec(#[from] CodecError),
-}
-
-impl From<io::Error> for ClientCodecError {
-    fn from(err: io::Error) -> Self {
-        ClientCodecError::Codec(CodecError::from(err))
-    }
-}
-
-impl From<prost::EncodeError> for ClientCodecError {
-    fn from(err: prost::EncodeError) -> Self {
-        ClientCodecError::Codec(CodecError::from(err))
-    }
-}
-
-impl From<prost::DecodeError> for ClientCodecError {
-    fn from(err: prost::DecodeError) -> Self {
-        ClientCodecError::Codec(CodecError::from(err))
-    }
+    #[error(transparent)]
+    Io(#[from] io::Error),
 }

--- a/crates/server/src/parser.rs
+++ b/crates/server/src/parser.rs
@@ -103,10 +103,18 @@ impl TryFrom<u8> for ServerInboundCommand {
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
-            _ if value == <pb::Connect as CommandCodec>::COMMAND => Ok(ServerInboundCommand::Connect),
-            _ if value == <pb::Publish as CommandCodec>::COMMAND => Ok(ServerInboundCommand::Publish),
-            _ if value == <pb::Subscribe as CommandCodec>::COMMAND => Ok(ServerInboundCommand::Subscribe),
-            _ if value == <pb::UnSubscribe as CommandCodec>::COMMAND => Ok(ServerInboundCommand::UnSubscribe),
+            _ if value == <pb::Connect as CommandCodec>::COMMAND => {
+                Ok(ServerInboundCommand::Connect)
+            }
+            _ if value == <pb::Publish as CommandCodec>::COMMAND => {
+                Ok(ServerInboundCommand::Publish)
+            }
+            _ if value == <pb::Subscribe as CommandCodec>::COMMAND => {
+                Ok(ServerInboundCommand::Subscribe)
+            }
+            _ if value == <pb::UnSubscribe as CommandCodec>::COMMAND => {
+                Ok(ServerInboundCommand::UnSubscribe)
+            }
             _ => Err(()),
         }
     }
@@ -125,7 +133,9 @@ impl TryFrom<u8> for ClientInboundCommand {
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
             _ if value == <pb::Info as CommandCodec>::COMMAND => Ok(ClientInboundCommand::Info),
-            _ if value == <pb::Message as CommandCodec>::COMMAND => Ok(ClientInboundCommand::Message),
+            _ if value == <pb::Message as CommandCodec>::COMMAND => {
+                Ok(ClientInboundCommand::Message)
+            }
             _ => Err(()),
         }
     }
@@ -665,7 +675,7 @@ mod tests {
         let mut server_codec = ServerCodec;
         let mut output_buffer = BytesMut::new();
 
-        server_codec.encode(unsubscribe.clone(), &mut output_buffer).unwrap();
+        server_codec.encode(unsubscribe, &mut output_buffer).unwrap();
 
         let decoded = server_codec.decode(&mut output_buffer).unwrap().unwrap();
         let Frame::UnSubscribe(message) = decoded else { panic!("expected UnSubscribe frame") };
@@ -725,11 +735,8 @@ mod tests {
 
     #[tokio::test]
     async fn framed_read_decodes_publish_subscribe_unsubscribe_sequence() {
-        let publish = pb::Publish {
-            topic: b"a/b".to_vec(),
-            payload: b"payload".to_vec(),
-            header: vec![],
-        };
+        let publish =
+            pb::Publish { topic: b"a/b".to_vec(), payload: b"payload".to_vec(), header: vec![] };
         let subscribe = pb::Subscribe {
             topic: b"a/#".to_vec(),
             subscription_id: 1,

--- a/crates/server/src/parser.rs
+++ b/crates/server/src/parser.rs
@@ -20,6 +20,10 @@ pub const PROTOCOL_VERSION: u32 = 1;
 pub enum Command {
     Info = 0x00,
     Connect = 0x01,
+    Publish = 0x02,
+    Subscribe = 0x03,
+    UnSubscribe = 0x04,
+    Message = 0x05,
     // TODO: add Err command.
 }
 
@@ -46,37 +50,64 @@ impl CommandCodec for pb::Connect {
     const COMMAND: u8 = Command::Connect as u8;
 }
 
+impl CommandCodec for pb::Publish {
+    const COMMAND: u8 = Command::Publish as u8;
+}
+
+impl CommandCodec for pb::Subscribe {
+    const COMMAND: u8 = Command::Subscribe as u8;
+}
+
+impl CommandCodec for pb::UnSubscribe {
+    const COMMAND: u8 = Command::UnSubscribe as u8;
+}
+
+impl CommandCodec for pb::Message {
+    const COMMAND: u8 = Command::Message as u8;
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum Frame {
     Connect(pb::Connect),
+    Publish(pb::Publish),
+    Subscribe(pb::Subscribe),
+    UnSubscribe(pb::UnSubscribe),
 }
 
 #[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq)]
 pub enum ClientFrame {
     Info(pb::Info),
+    Message(pb::Message),
 }
 
 /// Messages the server sends to a connected client.
 /// Used as the element type for the outbound write-buffer channel.
+#[allow(dead_code)]
 pub enum OutboundMessage {
     Info(pb::Info),
-    // TODO: Publish(pb::Publish), Pong, Error(pb::Error), etc.
+    Message(pb::Message),
+    // TODO: Pong, Error(pb::Error), etc.
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ServerInboundCommand {
     Connect,
+    Publish,
+    Subscribe,
+    UnSubscribe,
 }
 
 impl TryFrom<u8> for ServerInboundCommand {
     type Error = ();
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
-        if value == <pb::Connect as CommandCodec>::COMMAND {
-            Ok(ServerInboundCommand::Connect)
-        } else {
-            Err(())
+        match value {
+            _ if value == <pb::Connect as CommandCodec>::COMMAND => Ok(ServerInboundCommand::Connect),
+            _ if value == <pb::Publish as CommandCodec>::COMMAND => Ok(ServerInboundCommand::Publish),
+            _ if value == <pb::Subscribe as CommandCodec>::COMMAND => Ok(ServerInboundCommand::Subscribe),
+            _ if value == <pb::UnSubscribe as CommandCodec>::COMMAND => Ok(ServerInboundCommand::UnSubscribe),
+            _ => Err(()),
         }
     }
 }
@@ -85,16 +116,17 @@ impl TryFrom<u8> for ServerInboundCommand {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ClientInboundCommand {
     Info,
+    Message,
 }
 
 impl TryFrom<u8> for ClientInboundCommand {
     type Error = ();
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
-        if value == <pb::Info as CommandCodec>::COMMAND {
-            Ok(ClientInboundCommand::Info)
-        } else {
-            Err(())
+        match value {
+            _ if value == <pb::Info as CommandCodec>::COMMAND => Ok(ClientInboundCommand::Info),
+            _ if value == <pb::Message as CommandCodec>::COMMAND => Ok(ClientInboundCommand::Message),
+            _ => Err(()),
         }
     }
 }
@@ -216,6 +248,15 @@ impl Decoder for ServerCodec {
                 ServerInboundCommand::Connect => {
                     Frame::Connect(pb::Connect::decode_payload(&payload_bytes)?)
                 }
+                ServerInboundCommand::Publish => {
+                    Frame::Publish(pb::Publish::decode_payload(&payload_bytes)?)
+                }
+                ServerInboundCommand::Subscribe => {
+                    Frame::Subscribe(pb::Subscribe::decode_payload(&payload_bytes)?)
+                }
+                ServerInboundCommand::UnSubscribe => {
+                    Frame::UnSubscribe(pb::UnSubscribe::decode_payload(&payload_bytes)?)
+                }
             };
             return Ok(Some(frame));
         }
@@ -279,6 +320,9 @@ impl Decoder for ClientCodec {
             let frame = match command {
                 ClientInboundCommand::Info => {
                     ClientFrame::Info(pb::Info::decode_payload(&payload_bytes)?)
+                }
+                ClientInboundCommand::Message => {
+                    ClientFrame::Message(pb::Message::decode_payload(&payload_bytes)?)
                 }
             };
             return Ok(Some(frame));
@@ -390,6 +434,7 @@ mod tests {
                 assert_eq!(message.server_id, info.server_id);
                 assert_eq!(message.max_payload, info.max_payload);
             }
+            ClientFrame::Message(_) => panic!("unexpected Message frame"),
         }
         assert!(output_buffer.is_empty());
     }
@@ -445,6 +490,7 @@ mod tests {
             ClientFrame::Info(message) => {
                 assert_eq!(message.server_id, info.server_id);
             }
+            ClientFrame::Message(_) => panic!("unexpected Message frame"),
         }
         assert!(incoming_bytes.is_empty());
     }
@@ -472,6 +518,7 @@ mod tests {
                 assert_eq!(message.server_id, info.server_id);
                 assert_eq!(message.max_payload, info.max_payload);
             }
+            ClientFrame::Message(_) => panic!("unexpected Message frame"),
         }
         assert!(output_buffer.is_empty());
     }
@@ -526,6 +573,182 @@ mod tests {
 
         let frame = framed.next().await.unwrap().unwrap();
         assert!(matches!(frame, Frame::Connect(_)));
+        assert!(framed.next().await.is_none());
+    }
+
+    // --- Publish ---
+
+    #[test]
+    fn encode_and_decode_publish_frame() {
+        let publish = pb::Publish {
+            topic: b"sensors/temperature".to_vec(),
+            payload: b"42.5".to_vec(),
+            header: b"content-type:text/plain".to_vec(),
+        };
+        let mut server_codec = ServerCodec;
+        let mut output_buffer = BytesMut::new();
+
+        server_codec.encode(publish.clone(), &mut output_buffer).unwrap();
+
+        let decoded = server_codec.decode(&mut output_buffer).unwrap().unwrap();
+        let Frame::Publish(message) = decoded else { panic!("expected Publish frame") };
+        assert_eq!(message.topic, publish.topic);
+        assert_eq!(message.payload, publish.payload);
+        assert_eq!(message.header, publish.header);
+        assert!(output_buffer.is_empty());
+    }
+
+    #[test]
+    fn encode_publish_frame_has_correct_header() {
+        let publish = pb::Publish {
+            topic: b"test/topic".to_vec(),
+            payload: b"hello".to_vec(),
+            header: vec![],
+        };
+        let mut codec = ServerCodec;
+        let mut output_buffer = BytesMut::new();
+
+        codec.encode(publish, &mut output_buffer).unwrap();
+
+        assert!(output_buffer.len() >= HEADER_LENGTH);
+        assert_eq!(output_buffer[0], Command::Publish as u8);
+
+        let mut header_bytes = &output_buffer[COMMAND_BYTE_LEN..HEADER_LENGTH];
+        let payload_length = header_bytes.get_u32() as usize;
+        assert_eq!(payload_length, output_buffer.len() - HEADER_LENGTH);
+    }
+
+    // --- Subscribe ---
+
+    #[test]
+    fn encode_and_decode_subscribe_frame() {
+        let subscribe = pb::Subscribe {
+            topic: b"sensors/#".to_vec(),
+            subscription_id: 7,
+            queue_group: "workers".to_string(),
+        };
+        let mut server_codec = ServerCodec;
+        let mut output_buffer = BytesMut::new();
+
+        server_codec.encode(subscribe.clone(), &mut output_buffer).unwrap();
+
+        let decoded = server_codec.decode(&mut output_buffer).unwrap().unwrap();
+        let Frame::Subscribe(message) = decoded else { panic!("expected Subscribe frame") };
+        assert_eq!(message.topic, subscribe.topic);
+        assert_eq!(message.subscription_id, subscribe.subscription_id);
+        assert_eq!(message.queue_group, subscribe.queue_group);
+        assert!(output_buffer.is_empty());
+    }
+
+    #[test]
+    fn subscribe_without_queue_group_roundtrips() {
+        let subscribe = pb::Subscribe {
+            topic: b"events/+/status".to_vec(),
+            subscription_id: 1,
+            queue_group: String::new(),
+        };
+        let mut server_codec = ServerCodec;
+        let mut output_buffer = BytesMut::new();
+
+        server_codec.encode(subscribe.clone(), &mut output_buffer).unwrap();
+        let decoded = server_codec.decode(&mut output_buffer).unwrap().unwrap();
+        let Frame::Subscribe(message) = decoded else { panic!("expected Subscribe frame") };
+        assert_eq!(message.subscription_id, subscribe.subscription_id);
+        assert!(message.queue_group.is_empty());
+    }
+
+    // --- UnSubscribe ---
+
+    #[test]
+    fn encode_and_decode_unsubscribe_frame() {
+        let unsubscribe = pb::UnSubscribe { subscription_id: 42 };
+        let mut server_codec = ServerCodec;
+        let mut output_buffer = BytesMut::new();
+
+        server_codec.encode(unsubscribe.clone(), &mut output_buffer).unwrap();
+
+        let decoded = server_codec.decode(&mut output_buffer).unwrap().unwrap();
+        let Frame::UnSubscribe(message) = decoded else { panic!("expected UnSubscribe frame") };
+        assert_eq!(message.subscription_id, unsubscribe.subscription_id);
+        assert!(output_buffer.is_empty());
+    }
+
+    // --- Message ---
+
+    #[test]
+    fn encode_and_decode_message_frame() {
+        let message = pb::Message {
+            topic: b"sensors/temperature".to_vec(),
+            subscription_id: 3,
+            payload: b"23.1".to_vec(),
+            header: b"encoding:utf-8".to_vec(),
+        };
+        let mut server_codec = ServerCodec;
+        let mut client_codec = ClientCodec;
+        let mut output_buffer = BytesMut::new();
+
+        server_codec.encode(message.clone(), &mut output_buffer).unwrap();
+
+        let decoded = client_codec.decode(&mut output_buffer).unwrap().unwrap();
+        let ClientFrame::Message(delivered) = decoded else { panic!("expected Message frame") };
+        assert_eq!(delivered.topic, message.topic);
+        assert_eq!(delivered.subscription_id, message.subscription_id);
+        assert_eq!(delivered.payload, message.payload);
+        assert_eq!(delivered.header, message.header);
+        assert!(output_buffer.is_empty());
+    }
+
+    #[test]
+    fn client_decode_message_frame_recovers_from_bad_prefix() {
+        let message = pb::Message {
+            topic: b"test/topic".to_vec(),
+            subscription_id: 5,
+            payload: b"data".to_vec(),
+            header: vec![],
+        };
+        let payload = message.encode_to_vec();
+
+        let mut incoming_bytes = BytesMut::new();
+        incoming_bytes.put_u8(0xFF); // invalid command byte to force resync
+        incoming_bytes.put_u8(Command::Message as u8);
+        incoming_bytes.put_u32(payload.len() as u32);
+        incoming_bytes.extend_from_slice(&payload);
+
+        let mut codec = ClientCodec;
+        let decoded = codec.decode(&mut incoming_bytes).unwrap().unwrap();
+        let ClientFrame::Message(delivered) = decoded else { panic!("expected Message frame") };
+        assert_eq!(delivered.subscription_id, message.subscription_id);
+        assert!(incoming_bytes.is_empty());
+    }
+
+    // --- Mixed frame sequence ---
+
+    #[tokio::test]
+    async fn framed_read_decodes_publish_subscribe_unsubscribe_sequence() {
+        let publish = pb::Publish {
+            topic: b"a/b".to_vec(),
+            payload: b"payload".to_vec(),
+            header: vec![],
+        };
+        let subscribe = pb::Subscribe {
+            topic: b"a/#".to_vec(),
+            subscription_id: 1,
+            queue_group: String::new(),
+        };
+        let unsubscribe = pb::UnSubscribe { subscription_id: 1 };
+
+        let mut client_codec = ClientCodec;
+        let mut buf = BytesMut::new();
+        client_codec.encode(publish, &mut buf).unwrap();
+        client_codec.encode(subscribe, &mut buf).unwrap();
+        client_codec.encode(unsubscribe, &mut buf).unwrap();
+
+        let cursor = Cursor::new(buf.to_vec());
+        let mut framed = FramedRead::with_capacity(cursor, ServerCodec, 32 * 1024);
+
+        assert!(matches!(framed.next().await.unwrap().unwrap(), Frame::Publish(_)));
+        assert!(matches!(framed.next().await.unwrap().unwrap(), Frame::Subscribe(_)));
+        assert!(matches!(framed.next().await.unwrap().unwrap(), Frame::UnSubscribe(_)));
         assert!(framed.next().await.is_none());
     }
 }

--- a/crates/server/tests/protocol.rs
+++ b/crates/server/tests/protocol.rs
@@ -107,6 +107,12 @@ async fn info_then_connect_over_quic() -> Result<(), TestError> {
     let info_message =
         match read_next_client_frame(&mut receive_stream, &mut incoming_bytes).await? {
             Some(ClientFrame::Info(message)) => message,
+            Some(_) => {
+                return Err(Box::from(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "expected INFO, got unexpected frame",
+                )));
+            }
             None => {
                 return Err(Box::from(std::io::Error::new(
                     std::io::ErrorKind::UnexpectedEof,
@@ -157,6 +163,12 @@ async fn connect_timeout_when_no_connect_message() -> Result<(), TestError> {
     let _info_message =
         match read_next_client_frame(&mut receive_stream, &mut incoming_bytes).await? {
             Some(ClientFrame::Info(message)) => message,
+            Some(_) => {
+                return Err(Box::from(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "expected INFO, got unexpected frame",
+                )));
+            }
             None => {
                 return Err(Box::from(std::io::Error::new(
                     std::io::ErrorKind::UnexpectedEof,

--- a/proto/ocypode/pubsub/v1/pubsub.proto
+++ b/proto/ocypode/pubsub/v1/pubsub.proto
@@ -67,3 +67,67 @@ message PasswordAuth {
   string username = 1;
   string password = 2;
 }
+
+// Publish sends a message to the specified topic.
+// Brokers route this to all matching subscribers without inspecting the payload or header.
+message Publish {
+    // Topic to publish to, encoded as UTF-8 bytes.
+    // Default maximum length is 256 bytes, up to 8 hierarchy levels separated by '/'.
+    // Must not start or end with '/'. Case-sensitive. Spaces and special characters
+    // (e.g., '@', '%') are not allowed. Topics prefixed with '$SYS' are reserved for
+    // system metadata.
+    bytes topic = 1;
+
+    // Arbitrary application payload. The broker does not parse this field.
+    // Maximum size (including header) defaults to 1 MiB; the actual limit is
+    // communicated to the client in the Info message.
+    bytes payload = 2;
+
+    // Optional metadata attached to the message. The broker does not parse this field.
+    // Its size counts toward the max_payload limit.
+    bytes header = 3;
+}
+
+// Subscribe registers interest in a topic.
+// The broker will deliver matching messages to this client using the assigned subscription_id.
+message Subscribe {
+    // Topic filter to subscribe to, encoded as UTF-8 bytes.
+    // Supports wildcard matching: '+' matches exactly one hierarchy level,
+    // '#' matches one or more remaining levels and may only appear as the last segment.
+    // Topic rules (max length, hierarchy depth, character restrictions) apply as in Publish.
+    bytes topic = 1;
+
+    // Client-assigned identifier, unique per subscription within this connection.
+    // All subsequent Message deliveries and UnSubscribe requests for this subscription
+    // reference this ID.
+    uint32 subscription_id = 2;
+
+    // Optional queue group name for load-balanced delivery.
+    // When multiple subscribers share the same queue_group name, the broker delivers
+    // each message to exactly one member of the group in round-robin order.
+    // Groups are scoped per tenant; identical names in different tenants are independent.
+    string queue_group = 3;
+}
+
+// UnSubscribe cancels an active subscription identified by subscription_id.
+// After this message is processed, the broker will stop delivering messages for
+// that subscription to this client.
+message UnSubscribe {
+    // Identifier of the subscription to cancel, as assigned by the client in Subscribe.
+    uint32 subscription_id = 2;
+}
+
+// Message is delivered by the broker to a subscriber when a matching Publish is received.
+message Message {
+    // Topic the original message was published to, encoded as UTF-8 bytes.
+    bytes topic = 1;
+
+    // Subscription identifier that matched this delivery, as assigned by the client in Subscribe.
+    uint32 subscription_id = 2;
+
+    // Application payload forwarded from the original Publish. The broker does not parse this field.
+    bytes payload = 3;
+
+    // Metadata forwarded from the original Publish. The broker does not parse this field.
+    bytes header = 4;
+}


### PR DESCRIPTION
This pull request introduces several new message types to the `proto/ocypode/pubsub/v1/pubsub.proto` file, significantly expanding the pub/sub protocol's capabilities. The additions provide support for publishing messages, subscribing to topics (with wildcards and queue groups), unsubscribing, and message delivery to subscribers. These changes lay the foundation for a robust publish-subscribe system.

New pub/sub protocol messages:

**Publishing and subscribing functionality:**

* Added `Publish` message type, allowing clients to send messages to specific topics with payload and optional metadata.
* Added `Subscribe` message type, enabling clients to register interest in topic filters (including wildcard support) and specify queue groups for load-balanced delivery.
* Added `UnSubscribe` message type to allow clients to cancel active subscriptions using a subscription identifier.

**Message delivery:**

* Added `Message` message type, which the broker uses to deliver published messages to subscribers, including topic, subscription ID, payload, and header.