### PR TITLE
Expand Clippy invocation in justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -7,8 +7,8 @@ fmt:
 
 # Lint Rust Code
 lint:
-    cargo clippy
+    cargo clippy --all-targets --all-features -- -D warnings
 
 # Fix lint Rust Code
 lint-fix:
-    cargo clippy --fix --allow-dirty
+    cargo clippy --all-targets --all-features --fix --allow-dirty


### PR DESCRIPTION
Run Clippy across all targets and features and treat warnings as errors. Update lint-fix to apply fixes for all targets and features while allowing a
dirty workspace.