### PR TITLE
Introduce ClientId newtype for client IDs

### DIFF
--- a/crates/server/src/client.rs
+++ b/crates/server/src/client.rs
@@ -14,7 +14,7 @@ use tokio::{
     sync::mpsc,
 };
 use tokio_stream::StreamExt;
-use tokio_util::codec::{FramedRead, FramedWrite};
+use tokio_util::{codec::{FramedRead, FramedWrite}};
 
 static CLIENT_ID_COUNTER: AtomicU64 = AtomicU64::new(1);
 
@@ -43,10 +43,26 @@ impl From<mpsc::error::SendError<OutboundMessage>> for ClientError {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ClientId(pub u64);
+
+impl ClientId {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> ClientId {
+        ClientId(CLIENT_ID_COUNTER.fetch_add(1, Ordering::Relaxed))
+    }
+}
+
+impl std::fmt::Display for ClientId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 /// Server-side representation of a connected client.
 /// Created immediately after the QUIC stream is accepted, before the handshake.
 pub struct Client<R: AsyncRead + Unpin + Send> {
-    client_id: u64,
+    client_id: ClientId,
     /// Read buffer (FramedRead holds a 32 KiB byte buffer internally).
     framed_read: FramedRead<R, ServerCodec>,
     /// Sender end of the outbound write-buffer channel.
@@ -64,7 +80,7 @@ impl<R: AsyncRead + Unpin + Send + 'static> Client<R> {
         authenticator: Arc<dyn Authenticator>,
         config: Arc<ServerConfig>,
     ) -> Self {
-        let client_id = CLIENT_ID_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let client_id = ClientId::new();
         let (reader, writer) = transport.into_split();
         let framed_read =
             FramedRead::with_capacity(reader, ServerCodec, config.quic.read_buffer_size);

--- a/crates/server/src/handshake.rs
+++ b/crates/server/src/handshake.rs
@@ -6,17 +6,18 @@ use thiserror::Error;
 
 use crate::{
     auth::{AuthOutcome, Authenticator},
+    client::ClientId,
     parser::pb,
 };
 
 /// Initial state: INFO has been sent to the client, CONNECT has not yet arrived.
 pub struct PendingHandshake {
-    pub client_id: u64,
+    pub client_id: ClientId,
 }
 
 /// Terminal state: CONNECT received and authentication succeeded.
 pub struct CompletedHandshake {
-    pub client_id: u64,
+    pub client_id: ClientId,
     /// The CONNECT message received from the client; available for future dispatch logic.
     #[allow(dead_code)]
     pub connect_info: pb::Connect,
@@ -37,7 +38,7 @@ pub enum HandshakeError {
 }
 
 impl PendingHandshake {
-    pub fn new(client_id: u64) -> Self {
+    pub fn new(client_id: ClientId) -> Self {
         Self { client_id }
     }
 
@@ -65,7 +66,8 @@ mod tests {
 
     #[test]
     fn on_connect_transitions_to_completed_with_no_auth() {
-        let pending = PendingHandshake::new(42);
+        let client_id = ClientId::new();
+        let pending = PendingHandshake::new(client_id);
         let connect = pb::Connect {
             version: 1,
             verbose: false,
@@ -73,6 +75,6 @@ mod tests {
             credentials: None,
         };
         let completed = pending.on_connect(connect, &NoAuthAuthenticator).unwrap();
-        assert_eq!(completed.client_id, 42);
+        assert_eq!(completed.client_id, client_id);
     }
 }

--- a/crates/server/src/parser.rs
+++ b/crates/server/src/parser.rs
@@ -2,7 +2,10 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use prost::Message;
 use tokio_util::codec::{Decoder, Encoder};
 
-use crate::error::{ClientCodecError, CodecError, ServerCodecError};
+use crate::{
+    client::ClientId,
+    error::{ClientCodecError, CodecError, ServerCodecError},
+};
 pub mod pb {
     include!(concat!(env!("OUT_DIR"), "/ocypode.pubsub.v1.rs"));
 }
@@ -148,7 +151,7 @@ impl ServerOutbound {
     /// Creates an INFO message with specified parameters
     pub fn info(
         version: u32,
-        client_id: u64,
+        client_id: ClientId,
         server_id: String,
         server_name: String,
         requires_auth: bool,
@@ -159,7 +162,7 @@ impl ServerOutbound {
             server_id,
             server_name,
             max_payload: MAXIMUM_PAYLOAD_BYTES as u32,
-            client_id,
+            client_id: client_id.0,
             requires_auth,
             tls_verify,
         }
@@ -169,7 +172,7 @@ impl ServerOutbound {
     /// TODO: Load INFO message from configuration instead of using dummy values
     #[allow(dead_code)]
     pub fn default_info() -> pb::Info {
-        Self::info(1, 0, "ocypode-server".to_string(), "ocypode".to_string(), false, false)
+        Self::info(1, ClientId(0), "ocypode-server".to_string(), "ocypode".to_string(), false, false)
     }
 }
 


### PR DESCRIPTION
Add ClientId wrapper type (derive Debug/Clone/Copy/PartialEq/Eq/Hash) and Display. Introduce a global AtomicU64 counter and ClientId::new() for generating IDs. Replace raw u64 client_id fields and constructors in client, handshake, and parser code to use ClientId. Adjust parser.info
to set the protobuf field from client_id.0 and update tests accordingly.