### PR TITLE
Implement Router::insert and add transport module

### DIFF
--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -8,4 +8,5 @@ pub mod parser;
 pub mod permission;
 pub mod quic;
 pub mod router;
+pub mod topic;
 pub mod transport;

--- a/crates/server/src/router.rs
+++ b/crates/server/src/router.rs
@@ -3,7 +3,10 @@ use std::collections::HashMap;
 use bytes::Bytes;
 use tokio::sync::mpsc::Sender;
 
-use crate::client::ClientId;
+use crate::{
+    client::ClientId,
+    topic::{TopicFilter, WILDCARD_MULTI, WILDCARD_SINGLE},
+};
 
 #[allow(dead_code)]
 pub(crate) struct Subscription {
@@ -58,12 +61,33 @@ impl Router {
 
     pub(crate) fn insert(
         &mut self,
-        _tx: Sender<Bytes>,
-        _client_id: ClientId,
-        _subscription_id: u32,
-        _topic: Bytes,
+        tx: Sender<Bytes>,
+        client_id: ClientId,
+        subscription_id: u32,
+        topic: TopicFilter,
     ) {
-        todo!()
+        let mut node = &mut self.root;
+        for segment in topic.segments() {
+            // Wildcard flags on the parent are used during search to identify which
+            // branches to explore when delivering messages to matching subscribers.
+            if segment == WILDCARD_SINGLE {
+                node.has_single_wildcard = true;
+            } else if segment == WILDCARD_MULTI {
+                node.has_multi_wildcard = true;
+            }
+            node.is_leaf = false;
+            let children = node.children.get_or_insert_with(Vec::new);
+            let child_idx = match children.iter().position(|n| n.level == segment) {
+                Some(pos) => pos,
+                None => {
+                    children
+                        .push(Node { level: Bytes::copy_from_slice(segment), ..Node::default() });
+                    children.len() - 1
+                }
+            };
+            node = &mut children[child_idx];
+        }
+        node.subscription_map.insert(client_id, Subscription { subscription_id, tx });
     }
 
     pub(crate) fn search(&self, _topic: &Bytes) -> SubscriptionResponse {
@@ -78,5 +102,98 @@ impl Router {
 impl Default for Router {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::BytesMut;
+    use tokio::sync::mpsc::Sender;
+
+    use super::*;
+    use crate::client::ClientId;
+
+    fn make_filter(s: &str) -> TopicFilter {
+        TopicFilter::new(BytesMut::from(s)).unwrap()
+    }
+
+    fn dummy_tx() -> Sender<Bytes> {
+        tokio::sync::mpsc::channel(1).0
+    }
+
+    #[tokio::test]
+    async fn insert_single_segment_creates_child() {
+        let mut router = Router::new();
+        router.insert(dummy_tx(), ClientId::new(), 1, make_filter("a"));
+        assert_eq!(router.root.children.as_ref().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn insert_multi_segment_creates_nested_children() {
+        let mut router = Router::new();
+        router.insert(dummy_tx(), ClientId::new(), 1, make_filter("a/b/c"));
+        let level1 = &router.root.children.as_ref().unwrap()[0];
+        let level2 = &level1.children.as_ref().unwrap()[0];
+        let level3 = &level2.children.as_ref().unwrap()[0];
+        assert_eq!(level1.level.as_ref(), b"a");
+        assert_eq!(level2.level.as_ref(), b"b");
+        assert_eq!(level3.level.as_ref(), b"c");
+    }
+
+    #[tokio::test]
+    async fn insert_marks_intermediate_nodes_as_non_leaf() {
+        let mut router = Router::new();
+        router.insert(dummy_tx(), ClientId::new(), 1, make_filter("a/b/c"));
+        let level1 = &router.root.children.as_ref().unwrap()[0];
+        let level2 = &level1.children.as_ref().unwrap()[0];
+        assert!(!level1.is_leaf);
+        assert!(!level2.is_leaf);
+    }
+
+    #[tokio::test]
+    async fn insert_leaf_node_contains_subscription() {
+        let mut router = Router::new();
+        let client_id = ClientId::new();
+        router.insert(dummy_tx(), client_id, 7, make_filter("a/b"));
+        let leaf = &router.root.children.as_ref().unwrap()[0].children.as_ref().unwrap()[0];
+        assert!(leaf.subscription_map.contains_key(&client_id));
+        assert_eq!(leaf.subscription_map[&client_id].subscription_id, 7);
+    }
+
+    #[tokio::test]
+    async fn insert_single_wildcard_sets_flag_on_parent() {
+        let mut router = Router::new();
+        router.insert(dummy_tx(), ClientId::new(), 1, make_filter("a/+/c"));
+        let level1 = &router.root.children.as_ref().unwrap()[0];
+        assert!(level1.has_single_wildcard);
+    }
+
+    #[tokio::test]
+    async fn insert_multi_wildcard_sets_flag_on_parent() {
+        let mut router = Router::new();
+        router.insert(dummy_tx(), ClientId::new(), 1, make_filter("a/#"));
+        let level1 = &router.root.children.as_ref().unwrap()[0];
+        assert!(level1.has_multi_wildcard);
+    }
+
+    #[tokio::test]
+    async fn insert_two_subscribers_same_topic() {
+        let mut router = Router::new();
+        router.insert(dummy_tx(), ClientId::new(), 1, make_filter("a/b"));
+        router.insert(dummy_tx(), ClientId::new(), 2, make_filter("a/b"));
+        let leaf = &router.root.children.as_ref().unwrap()[0].children.as_ref().unwrap()[0];
+        assert_eq!(leaf.subscription_map.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn insert_shares_common_prefix_nodes() {
+        let mut router = Router::new();
+        router.insert(dummy_tx(), ClientId::new(), 1, make_filter("a/b/c"));
+        router.insert(dummy_tx(), ClientId::new(), 2, make_filter("a/b/d"));
+        let level1 = &router.root.children.as_ref().unwrap()[0];
+        let level2 = &level1.children.as_ref().unwrap()[0];
+        assert_eq!(router.root.children.as_ref().unwrap().len(), 1);
+        assert_eq!(level1.children.as_ref().unwrap().len(), 1);
+        assert_eq!(level2.children.as_ref().unwrap().len(), 2);
     }
 }


### PR DESCRIPTION
Change Router::insert to accept TopicFilter and build the subscription trie. Iterate topic segments, set single/multi wildcard flags on parent nodes, mark intermediate nodes non-leaf, reuse shared-prefix children, and insert the Subscription (client_id, subscription_id, tx) into the leaf node's subscription_map.